### PR TITLE
Strengthen pretraining augmentations

### DIFF
--- a/configs/leader.yaml
+++ b/configs/leader.yaml
@@ -13,11 +13,11 @@ data:
   val_fraction: 0.05
   mean: [0.485, 0.456, 0.406]
   std: [0.229, 0.224, 0.225]
-  global_crop_scale: [0.32, 1.0]
-  local_crop_scale: [0.05, 0.32]
-  color_jitter: 0.2
-  color_jitter_saturation: 0.2
-  hed_jitter: 0.05
+  global_crop_scale: [0.2, 1.0]
+  local_crop_scale: [0.03, 0.25]
+  color_jitter: 0.45
+  color_jitter_saturation: 0.4
+  hed_jitter: 0.12
 
 model:
   type: dinov2_vits14_reg

--- a/configs/smoke.yaml
+++ b/configs/smoke.yaml
@@ -13,11 +13,11 @@ data:
   val_fraction: 0.05
   mean: [0.485, 0.456, 0.406]
   std: [0.229, 0.224, 0.225]
-  global_crop_scale: [0.32, 1.0]
-  local_crop_scale: [0.05, 0.32]
-  color_jitter: 0.2
-  color_jitter_saturation: 0.2
-  hed_jitter: 0.05
+  global_crop_scale: [0.2, 1.0]
+  local_crop_scale: [0.03, 0.25]
+  color_jitter: 0.45
+  color_jitter_saturation: 0.4
+  hed_jitter: 0.12
 
 model:
   type: dinov2_vits14_reg

--- a/dataloader.py
+++ b/dataloader.py
@@ -12,10 +12,8 @@
 # lightweight DINO/iBOT/KDE validation pass), so the held-out patient slice
 # stays cleanly out-of-distribution from optimization.
 #
-# Augmentation per tile: optional HEDJitter (stain-space color perturbation),
-# then train.global_views global crops + train.local_views local crops, each
-# chained as RandomResizedCrop -> horizontal flip -> vertical flip ->
-# ColorJitter -> Normalize.
+# Augmentation per view: RandomResizedCrop -> optional HEDJitter -> horizontal/
+# vertical flips -> ColorJitter -> occasional grayscale/blur -> Normalize.
 #
 # This file is the *pretraining* input pipeline only. The downstream probes
 # (probe.py) do not import anything from here.
@@ -74,7 +72,7 @@ class HEDJitter(nn.Module):
         self.register_buffer("hed_from_rgb", HED_FROM_RGB)
         self.register_buffer("rgb_from_hed", RGB_FROM_HED)
 
-    # Perturb HED channels, then convert back to RGB before the crop/flip/color pipeline.
+    # Perturb HED channels, then convert back to RGB while the crop is still in [0, 1].
     def forward(self, x):
         rgb = x.permute(1, 2, 0).clamp_min(1e-6)
         hed = (torch.log(rgb) / LOG_1E6) @ self.hed_from_rgb.to(dtype=x.dtype)
@@ -128,14 +126,16 @@ class TCGATileDataset(Dataset):
         self.global_views = int(train["global_views"])
         self.local_views = int(train["local_views"])
         self.to_tensor = v2.Compose([v2.ToImage(), v2.ToDtype(torch.float32, scale=True)])
-        self.hed_jitter = HEDJitter(data["hed_jitter"]) if data["hed_jitter"] > 0 else None
         # Global crops carry the high-context view used by the DINO/iBOT objectives.
         self.global_aug = v2.Compose(
             [
                 v2.RandomResizedCrop(train["global_size"], scale=tuple(data["global_crop_scale"]), antialias=True),
+                *([HEDJitter(data["hed_jitter"])] if data["hed_jitter"] > 0 else []),
                 v2.RandomHorizontalFlip(),
                 v2.RandomVerticalFlip(),
                 v2.ColorJitter(data["color_jitter"], data["color_jitter"], data["color_jitter_saturation"], 0.0),
+                v2.RandomGrayscale(p=0.1),
+                v2.RandomApply([v2.GaussianBlur(9, sigma=(0.1, 1.8))], p=0.35),
                 v2.Normalize(mean=mean, std=std),
             ]
         )
@@ -143,9 +143,12 @@ class TCGATileDataset(Dataset):
         self.local_aug = v2.Compose(
             [
                 v2.RandomResizedCrop(train["local_size"], scale=tuple(data["local_crop_scale"]), antialias=True),
+                *([HEDJitter(data["hed_jitter"])] if data["hed_jitter"] > 0 else []),
                 v2.RandomHorizontalFlip(),
                 v2.RandomVerticalFlip(),
                 v2.ColorJitter(data["color_jitter"], data["color_jitter"], data["color_jitter_saturation"], 0.0),
+                v2.RandomGrayscale(p=0.1),
+                v2.RandomApply([v2.GaussianBlur(9, sigma=(0.1, 1.8))], p=0.35),
                 v2.Normalize(mean=mean, std=std),
             ]
         )
@@ -176,10 +179,9 @@ class TCGATileDataset(Dataset):
         patient_id = "-".join(slide_stem.split("-")[:3])
         slide_key = int.from_bytes(hashlib.blake2b(slide_stem.encode(), digest_size=8).digest(), "big") & 0x7FFFFFFFFFFFFFFF
         patient_key = int.from_bytes(hashlib.blake2b(patient_id.encode(), digest_size=8).digest(), "big") & 0x7FFFFFFFFFFFFFFF
-        # Augmentations are stochastic; reproducibility comes from worker seeds.
-        context_tile = self.hed_jitter(tile) if self.hed_jitter is not None else tile
-        global_views = torch.stack([self.global_aug(context_tile) for _ in range(self.global_views)])
-        local_views = torch.stack([self.local_aug(context_tile) for _ in range(self.local_views)])
+        # Augmentations are stochastic per view; reproducibility comes from worker seeds.
+        global_views = torch.stack([self.global_aug(tile) for _ in range(self.global_views)])
+        local_views = torch.stack([self.local_aug(tile) for _ in range(self.local_views)])
         return {
             "global_views": global_views,
             "local_views": local_views,


### PR DESCRIPTION
## Summary

This PR strengthens the pretraining augmentation policy for Nanopath while keeping the codebase flat and local to the existing dataloader/config path.

Changes included here:
- Make global crops more aggressive: `global_crop_scale` changes from `[0.32, 1.0]` to `[0.2, 1.0]`.
- Make local crops smaller/tighter: `local_crop_scale` changes from `[0.05, 0.32]` to `[0.03, 0.25]`.
- Increase RGB color jitter from `0.2` to `0.45` and saturation jitter from `0.2` to `0.4`.
- Increase HED stain jitter from `0.05` to `0.12`.
- Move HED stain jitter into each global/local view transform after crop, so each view gets independent stain perturbation instead of sharing one tile-level perturbation.
- Add `RandomGrayscale(p=0.1)` and `GaussianBlur(kernel_size=9, sigma=(0.1, 1.8), p=0.35)` to both global and local views.
- Keep the existing horizontal and vertical flips.

## Why

The goal was to make the SSL views meaningfully harder without changing the training objective, probe code, benchmarking code, or model path. For histopathology, the useful invariances are mostly stain variation, scanner/blur variation, color response, tissue crop context, and flip symmetry. Applying HED jitter per view makes positive pairs less trivially color-matched, while the stronger crop ranges and grayscale/blur increase pressure on morphology rather than exact color/texture shortcuts.

This also keeps the implementation small: the augmentation policy stays directly in `dataloader.py`, and the tunable strengths stay in the existing YAML configs.

## Experiment Evidence

Full leader run for this final policy:
- Output: `/data/paul/nanopath/leader/augmentations_stronger`
- Labless submission: `08b694423e`
- Final `mean_probe_score`: `0.566772227192577`

We also tried a later, stronger variant that added random 90-degree rotations, raised HED jitter to `0.14`, and changed blur/ordering for speed. That completed and was submitted as `9cd07ae95e`, but it scored `0.5625624679025085`, so this PR intentionally reverts to the better `augmentations_stronger` policy and does not include `RandomRotate90`.

## Validation

- `python -m py_compile dataloader.py train.py`
- Real dataset sample through `TCGATileDataset` using `configs/smoke.yaml`:
  - `global_views`: `(2, 3, 224, 224)`, finite `float32`
  - `local_views`: `(8, 3, 98, 98)`, finite `float32`
- `git diff --check`
- Confirmed `probe.py` and `benchmarking/` are untouched.