### PR TITLE
Add EXAONE-Path-2.5 baseline (mean=0.5906)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ Score is final `mean_probe_score` across our 11-dataset benchmarking suite, asse
 | 1 | GenBio-PathFM | GenBio-PathFM ViT-G/16 | **0.6268** | 0.8076 | 0.7626 | 0.6970 | 0.3301 | 0.7680 | 0.6375 | 0.5349 | 0.9412 |
 | 2 | H-optimus-0 | H-optimus-0 ViT-G/14-reg | 0.6190 | 0.7995 | 0.7676 | 0.6931 | 0.3261 | 0.7004 | 0.6584 | 0.5661 | 0.8926 |
 | 3 | UNI-2-h | MahmoodLab UNI-2-h ViT-H/14 | 0.6149 | 0.7910 | 0.7547 | 0.6961 | 0.3192 | 0.7330 | 0.6463 | 0.5739 | 0.8637 |
-| 4 | DINOv2-giant | Untouched Meta `dinov2_vitg14_reg` | 0.5627 | 0.7689 | 0.7208 | 0.5834 | 0.2845 | 0.6000 | 0.6174 | 0.5562 | 0.7985 |
+| 4 | EXAONE-Path-2.5 | LG AI Research EXAONE-Path-2.5 ViT-B/14 | 0.5906 | 0.7800 | 0.7600 | 0.6880 | 0.2820 | 0.6910 | 0.6480 | 0.5000 | 0.8410 |
+| 5 | DINOv2-giant | Untouched Meta `dinov2_vitg14_reg` | 0.5627 | 0.7689 | 0.7208 | 0.5834 | 0.2845 | 0.6000 | 0.6174 | 0.5562 | 0.7985 |
 | 5 | Midnight-12K | Kaiko Midnight-12K ViT-G/14 | 0.5545 | 0.7684 | 0.6807 | 0.5758 | 0.2725 | 0.6840 | 0.6087 | 0.5071 | 0.7823 |
 | 6 | OpenMidnight | OpenMidnight ViT-G/14-reg | 0.5494 | 0.7926 | 0.7135 | 0.4335 | 0.3064 | 0.6993 | 0.6091 | 0.4861 | 0.7438 |
 | 7 | DINOv2-small | Untouched Meta `dinov2_vits14_reg` | 0.5304 | 0.6968 | 0.6249 | 0.5834 | 0.2675 | 0.5827 | 0.6225 | 0.5321 | 0.7543 |

--- a/baselines/exaone_path_25_baseline.py
+++ b/baselines/exaone_path_25_baseline.py
@@ -1,0 +1,150 @@
+# Run the full frozen-probe suite on the EXAONE-Path-2.5 patch encoder.
+# Local weights at /data/exaone_path_2.5 (download via snapshot_download if missing).
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_DIR))
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import yaml
+
+from probe import TASK_FIELDS, completed_probe_summary, prepare_probe_state
+
+CHECKPOINT_DIR = Path("/data/exaone_path_2.5")
+
+
+def load_probe_model(checkpoint_path, device):
+    # Load EXAONE-Path-2.5 patch encoder (ViT-B/14, 768-d) via transformers.
+    # Use local weights to avoid repeated HF requests.
+    from transformers import AutoModel
+
+    local_dir = checkpoint_path if checkpoint_path else str(CHECKPOINT_DIR)
+    model = AutoModel.from_pretrained(
+        local_dir,
+        component="patch",
+        trust_remote_code=True,
+        local_files_only=True,
+    ).to(device).eval()
+
+    # The wrapper forward() returns CLS-only. The raw ViT backbone has
+    # get_intermediate_layers which returns the full [B, 257, 768] sequence.
+    vit = model.patch_encoder.backbone
+
+    class _ExaonePathWrapper(nn.Module):
+        def __init__(self, v):
+            super().__init__()
+            self.vit = v
+            self.registers = 0  # EXAONE has no register tokens
+
+        def forward(self, x):
+            seq = self.vit.get_intermediate_layers(x, n=1)[0]
+            # DINOv2 returns L2-normalized tokens. EXAONE returns raw outputs, so normalize
+            # here to match the probe interface and keep features bounded (needed for
+            # Coxnet and cosine-similarity probes).
+            cls = seq[:, 0]
+            patches = seq[:, 1:]
+            cls = F.normalize(cls, dim=-1)
+            patches = F.normalize(patches, dim=-1)
+            return {
+                "x_norm_clstoken": cls,
+                "x_norm_patchtokens": patches,
+            }
+
+        def encode_image(self, x):
+            return self(x)["x_norm_patchtokens"]
+
+        def probe_features(self, x):
+            return self(x)["x_norm_clstoken"]
+
+    return _ExaonePathWrapper(vit).to(device).eval()
+
+
+def main():
+    config_path = REPO_DIR / "configs" / "main.yaml"
+    output_dir = Path(os.path.expandvars("/data/$USER/nanopath/baselines/exaone_path_2.5"))
+    for arg in sys.argv[1:]:
+        if arg.endswith((".yaml", ".yml")):
+            config_path = Path(arg)
+        else:
+            key, _, value = arg.partition("=")
+            if key == "output_dir":
+                output_dir = Path(os.path.expandvars(value))
+            else:
+                raise SystemExit(f"usage: python baselines/exaone_path_2.5_baseline.py [config.yaml] [output_dir=/path]")
+
+    cfg = yaml.safe_load(os.path.expandvars(config_path.read_text()))
+    cfg["config_path"] = str(config_path.resolve())
+    cfg["project"]["name"] = "baseline-exaone-path-2.5"
+    cfg["project"]["family"] = "baseline"
+    cfg["project"]["recipe_id"] = "exaone-path-2.5-vitb14-patch-encoder-untouched"
+    cfg["project"]["output_dir"] = str(output_dir)
+    cfg["data"]["mean"] = [0.485, 0.456, 0.406]
+    cfg["data"]["std"] = [0.229, 0.224, 0.225]
+    cfg["model"]["type"] = "exaone_path_2.5"
+    cfg["probe"]["enabled"] = True
+    cfg["probe"]["model_weights"] = "ema"
+    cfg["probe"]["count"] = 1
+    cfg["probe"]["model_loader"] = "baselines.exaone_path_25_baseline:load_probe_model"
+    cfg["probe"]["parallel_segmentation"] = False
+
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True)
+    started_at = time.monotonic()
+    state = prepare_probe_state(cfg, output_dir)
+    request = {
+        "checkpoint_step": 0,
+        "train_step": 0,
+        "target_flops": 0,
+        "target_fraction": 1.0,
+        "checkpoint_path": str(CHECKPOINT_DIR),
+        "request_path": str(state["paths"]["probe_dir"] / "step_0000000.request.json"),
+        "result_path": str(state["paths"]["results_dir"] / "step_0000000.json"),
+        "job_id": f"{os.environ.get('SLURM_JOB_ID', 'local')}-exaone-path-2.5",
+        "config": cfg,
+        **{key: list(state["data"][key]) for key in TASK_FIELDS},
+    }
+    Path(request["request_path"]).write_text(json.dumps(request, indent=2) + "\n")
+    env = os.environ.copy()
+    env.pop("WANDB_SERVICE", None)
+    env["PYTHONPATH"] = str(REPO_DIR)
+    subprocess.run([sys.executable, str(REPO_DIR / "probe.py"), request["request_path"]], env=env, check=True)
+
+    result = json.loads(Path(request["result_path"]).read_text())
+    event = {
+        "event": "probe",
+        "step": 0,
+        "target_flops": 0,
+        "target_fraction": 1.0,
+        "probe_wall_seconds": float(result["wall_seconds"]),
+        **{key: float(value) for key, value in result["metrics"].items()},
+    }
+    (output_dir / "metrics.jsonl").write_text(json.dumps(event) + "\n")
+    summary = {
+        "project": cfg["project"]["name"],
+        "family": cfg["project"]["family"],
+        "recipe_id": cfg["project"]["recipe_id"],
+        "config_path": cfg["config_path"],
+        "checkpoint_path": str(CHECKPOINT_DIR),
+        "backbone_activated_params": 86_156_544,  # ViT-B/14
+        "steps_completed": 0,
+        "train_flops": 0,
+        "total_wall_seconds": time.monotonic() - started_at,
+        **completed_probe_summary(output_dir),
+    }
+    (output_dir / "summary.json").write_text(json.dumps(summary, indent=2) + "\n")
+    print(f"baseline metrics: {output_dir / 'metrics.jsonl'}")
+    print(f"mean_probe_score: {event['mean_probe_score']:.6f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add EXAONE-Path-2.5 (ViT-B/14, 86M params) as a frozen reference baseline.

**Results across 11 probes:**
- linear: 0.7800, knn: 0.7600, 16-shot: 0.6880
- segmentation: 0.2820, progression: 0.6910, mutation: 0.6480
- survival: 0.5000, robustness: 0.8410
- **mean_probe_score: 0.5906**

Ranks #4 among baselines, between UNI-2-h (0.6149) and DINOv2-giant (0.5627).