### PR TITLE
Clarify Labless flow and fresh prepare setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ uv sync && source .venv/bin/activate
 wandb login  # optional; set WANDB_MODE=offline to keep W&B local
 
 # download pretraining & probe datasets & DINOv2 pretrained ckpt
-python prepare.py configs/smoke.yaml download=True
+python prepare.py download=True
 
 # smoke test: short training plus the fixed full probe suite
 sbatch submit/train_1gpu.sbatch configs/smoke.yaml
@@ -159,9 +159,9 @@ The script reads `summary.json` and `metrics.jsonl`, reviews `output_dir/labless
 
 ## Data
 
-`prepare.py` prepares the necessary data for pretraining and downstream probing. Flag `download=True` to fetch/prepare the configured datasets into the folders specified by the YAML; flag `download=False` to verify that all required paths are already populated.
+`prepare.py` prepares the necessary data for pretraining and downstream probing. By default it reads `configs/main.yaml`; pass a YAML path before the flag to prepare a different config, e.g. `python prepare.py configs/smoke.yaml download=True`. Flag `download=True` to fetch/prepare the configured datasets into the folders specified by the YAML; flag `download=False` to verify that all required paths are already populated.
 
-On the MedARC cluster, the checked-in `/data` and `/block` paths are the intended populated shared defaults. On a fresh clone, `prepare.py … download=True` rewrites any missing or empty checked-in data/probe roots to point into `nanopath/data/<name>`, preserving comments and formatting. It also moves `output_dir` and `wandb_dir` into `nanopath/data/` whenever a config's data roots are localized. The rewrite updates the config you pass plus the checked-in `configs/main.yaml` and `configs/smoke.yaml`, so running prepare on smoke first still leaves main directly runnable afterward. This happens even if the machine has a `/data` mount but lacks `/data/nanopath_parquet`. Populated shared roots are left unchanged. To force a different storage location, edit `data.dataset_dir`, `probe.dataset_roots.*`, `project.output_dir`, and `project.wandb_dir` to existing writable paths before downloading.
+On the MedARC cluster, the checked-in `/data` and `/block` paths are the intended populated shared defaults. On a fresh clone, `prepare.py … download=True` rewrites any missing or empty checked-in data/probe roots to point into `nanopath/data/<name>`, preserving comments and formatting. It also moves `output_dir` and `wandb_dir` into `nanopath/data/` whenever a config's data roots are localized. The rewrite updates the selected config plus the checked-in `configs/main.yaml` and `configs/smoke.yaml`, so running prepare once still leaves both smoke and main directly runnable afterward. This happens even if the machine has a `/data` mount but lacks `/data/nanopath_parquet`. Populated shared roots are left unchanged. To force a different storage location, edit `data.dataset_dir`, `probe.dataset_roots.*`, `project.output_dir`, and `project.wandb_dir` to existing writable paths before downloading.
 
 **What `download=True` does**
 1. **TCGA tiles**: `huggingface_hub.snapshot_download` (filtered to `shard-*.parquet`) pulls the 200 parquet shards (~120 GB total, `{path: string, jpeg: binary}` rows with 64-row row groups) from [`medarc/nanopath`](https://huggingface.co/datasets/medarc/nanopath) into `data.dataset_dir`.
@@ -218,7 +218,7 @@ sbatch submit/train_1gpu.sbatch configs/main.yaml
 
 ## Outputs
 
-The `/data`- and `/block`-rooted defaults below are the MedARC cluster layout; `prepare.py … download=True` rewrites missing or empty data/probe defaults in the requested config plus `configs/{main,smoke}.yaml` to live under `nanopath/data/` instead, and it localizes run outputs/W&B logs there too for those rewritten configs.
+The `/data`- and `/block`-rooted defaults below are the MedARC cluster layout; `prepare.py … download=True` rewrites missing or empty data/probe defaults in the selected config plus `configs/{main,smoke}.yaml` to live under `nanopath/data/` instead, and it localizes run outputs/W&B logs there too for those rewritten configs.
 
 - run outputs: `project.output_dir` (cluster default `/data/$USER/nanopath/main/...`; auto-localized default `nanopath/data/main/...`). Final probe results log to `metrics.jsonl`.
 - wandb: `project.wandb_dir` (cluster default `/data/$USER/nanopath/wandb`; auto-localized default `nanopath/data/wandb`).

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ sbatch submit/train_1gpu.sbatch configs/main.yaml output_dir=$RUN_DIR
 # or directly on a GPU machine: python train.py configs/main.yaml output_dir=$RUN_DIR
 
 # publish a completed full run to the live labless plot
+# the submitter will ask you to sign in with GitHub in a browser
 ./labless/submit_to_labless.py output_dir=$RUN_DIR run_name=kde-crops notes="what changed"
 ```
 
@@ -71,18 +72,36 @@ Baseline rows are frozen reference checkpoints evaluated with the same probe sui
 
 ### How to submit to the leaderboard
 
-`configs/main.yaml` is the current `nanopath` main-branch training recipe. Submit completed full runs to labless:
+Labless is the public run ledger and live plot for `nanopath`. You do not need a Labless password or a pull request to make a leaderboard claim; the submitter connects your submission to your GitHub identity through GitHub's no-scope device sign-in flow.
+
+`configs/main.yaml` is the current `nanopath` main-branch training recipe. A normal submission is:
 
 ```bash
 RUN_DIR=/data/$USER/nanopath/main/my-run
 ./labless/submit_to_labless.py output_dir=$RUN_DIR run_name=kde-crops notes="what changed and why"
 ```
 
-The `run_name` is the short label shown next to your dot on the Labless plot; keep it under 20 characters and make it describe what changed. A copied config such as `configs/new_config.yaml` is fine if the completed `summary.json` still reports `max_train_samples: 1000000`, `tile_presentations <= 1000000`, and `max_train_flops: 1e18`. Short smoke-sized runs and failed runs are not public Labless submissions.
+The pipeline is:
+
+1. Train a completed full run with `configs/main.yaml` or a copied `configs/*.yaml` that keeps the locked probe suite intact.
+2. Let `train.py` finish the final probe. The run directory must contain `summary.json`, `metrics.jsonl`, and the source snapshot written at launch under `labless_source/`.
+3. Run `./labless/submit_to_labless.py ...` from the repo root. It writes `labless_submission.json`, checks the run caps and locked benchmark surface, then prints a GitHub device-login URL and one-time code.
+4. Open the URL on any machine, sign in to GitHub, and enter the code. Labless records that verified GitHub login as the contributor, posts the run to `api.labless.dev`, and shows it as `pending` until maintainer validation.
+
+Public full-run submissions must satisfy:
+
+- `summary.max_train_samples == 1000000`
+- `summary.tile_presentations <= 1000000`
+- `summary.max_train_flops == 1e18`
+- final `mean_probe_score` / `final_probe_score` is present
+- no saved-source changes to `probe.py` or anything under `benchmarking/`
+- no locked probe config changes except local `probe.dataset_roots`
+
+The `run_name` is the short label shown next to your dot on the Labless plot; keep it under 20 characters and make it describe what changed. Short smoke-sized runs, failed runs, and runs missing the saved source snapshot stay local. Each verified GitHub login can submit at most 10 runs per 24 hours.
 
 To top the leaderboard you must beat the highest validated Labless run on `mean_probe_score` by at least 0.01. Submit the run to labless; that public submission is the leaderboard claim, with the saved source snapshot, changed files, notes, metrics, hardware, and optional W&B link attached. Public submissions have no wall-clock limit, so train on whatever hardware you have access to. [@PaulScotti](https://github.com/PaulScotti) will inspect promising submissions, rerun the candidate on the maintainer's single 80 GB H100 with a different rng seed, and validate it on Labless if training completes within 2 hours and the rerun still improves by at least 0.01. If its code is pushed to nanopath `main`, Labless marks that run separately as `main`. **You don't need an H100 or a PR to submit**; labless handles the public record and maintainer validation.
 
-Code-cleanup PRs are still welcome when they simplify the codebase without changing benchmark peformance on the main recipe. Leaderboard claims should go through labless instead of a pull request.
+Code-cleanup PRs are still welcome when they simplify the codebase without changing benchmark performance on the main recipe. Leaderboard claims should go through labless instead of a pull request.
 
 ### What you must NOT change for a leaderboard submission
 
@@ -118,7 +137,7 @@ RUN_DIR=/data/$USER/nanopath/main/my-run
 ./labless/submit_to_labless.py output_dir=$RUN_DIR run_name=kde-crops notes="what changed and why"
 ```
 
-The script reads `summary.json` and `metrics.jsonl`, uses the run's saved source snapshot (`output_dir/labless_source`), writes `labless_submission.json`, verifies full runs from `max_train_samples: 1000000`, `tile_presentations <= 1000000`, and `max_train_flops: 1e18`, signs you in through GitHub's no-scope device flow, and posts to `api.labless.dev`. Labless records the verified GitHub login and accepts at most 10 submissions per login per 24 hours. W&B can be online or offline; online runs add a public W&B link, while source review always comes from the local snapshot. Smoke checks and failed runs stay local. The labless website, run log, and plot update automatically; new completed full runs stay `pending` until maintainer validation. See [labless/README.md](labless/README.md) for details.
+The script reads `summary.json` and `metrics.jsonl`, reviews `output_dir/labless_source` rather than your current working tree, and posts the local payload in `labless_submission.json` after GitHub device sign-in succeeds. W&B can be online or offline; online runs add a public W&B link, while source review always comes from the local snapshot. The labless website, run log, and plot update automatically. See [labless/README.md](labless/README.md) for the exact payload fields, dry-run mode, baseline submission notes, and validation policy.
 
 ## Repository layout
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The script reads `summary.json` and `metrics.jsonl`, reviews `output_dir/labless
 
 `prepare.py` prepares the necessary data for pretraining and downstream probing. Flag `download=True` to fetch/prepare the configured datasets into the folders specified by the YAML; flag `download=False` to verify that all required paths are already populated.
 
-On the MedARC cluster, the checked-in `/data` and `/block` paths are the intended populated shared defaults. On a fresh clone, `prepare.py … download=True` rewrites any missing or empty checked-in data/probe roots in the config you pass to point into `nanopath/data/<name>`, preserving comments and formatting. This happens even if the machine has a `/data` mount but lacks `/data/nanopath_parquet`, so a successful prepare run leaves the YAML directly runnable by `train.py`/`probe.py` with no manual path edits. Populated shared roots are left unchanged. `output_dir` and `wandb_dir` are also localized when their absolute mount is absent or read-only. To force a different storage location, edit `data.dataset_dir` and `probe.dataset_roots.*` to existing writable paths before downloading.
+On the MedARC cluster, the checked-in `/data` and `/block` paths are the intended populated shared defaults. On a fresh clone, `prepare.py … download=True` rewrites any missing or empty checked-in data/probe roots to point into `nanopath/data/<name>`, preserving comments and formatting. It updates the config you pass plus the checked-in `configs/main.yaml` and `configs/smoke.yaml`, so running prepare on smoke first still leaves main directly runnable afterward. This happens even if the machine has a `/data` mount but lacks `/data/nanopath_parquet`. Populated shared roots are left unchanged. `output_dir` and `wandb_dir` are also localized when their absolute mount is absent or read-only. To force a different storage location, edit `data.dataset_dir` and `probe.dataset_roots.*` to existing writable paths before downloading.
 
 **What `download=True` does**
 1. **TCGA tiles**: `huggingface_hub.snapshot_download` (filtered to `shard-*.parquet`) pulls the 200 parquet shards (~120 GB total, `{path: string, jpeg: binary}` rows with 64-row row groups) from [`medarc/nanopath`](https://huggingface.co/datasets/medarc/nanopath) into `data.dataset_dir`.
@@ -218,7 +218,7 @@ sbatch submit/train_1gpu.sbatch configs/main.yaml
 
 ## Outputs
 
-The `/data`- and `/block`-rooted defaults below are the MedARC cluster layout; `prepare.py … download=True` rewrites missing or empty data/probe defaults in the config to live under `nanopath/data/` instead, and then downloads there.
+The `/data`- and `/block`-rooted defaults below are the MedARC cluster layout; `prepare.py … download=True` rewrites missing or empty data/probe defaults in the requested config plus `configs/{main,smoke}.yaml` to live under `nanopath/data/` instead, and then downloads there.
 
 - run outputs: `project.output_dir` (default is `/data/$USER/nanopath/main/...`). Final probe results log to `metrics.jsonl`.
 - wandb: `/data/$USER/nanopath/wandb`.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The script reads `summary.json` and `metrics.jsonl`, reviews `output_dir/labless
 
 `prepare.py` prepares the necessary data for pretraining and downstream probing. Flag `download=True` to fetch/prepare the configured datasets into the folders specified by the YAML; flag `download=False` to verify that all required paths are already populated.
 
-On the MedARC cluster, the checked-in `/data` and `/block` paths are the intended populated shared defaults. On a fresh clone, `prepare.py … download=True` rewrites any missing or empty checked-in data/probe roots to point into `nanopath/data/<name>`, preserving comments and formatting. It updates the config you pass plus the checked-in `configs/main.yaml` and `configs/smoke.yaml`, so running prepare on smoke first still leaves main directly runnable afterward. This happens even if the machine has a `/data` mount but lacks `/data/nanopath_parquet`. Populated shared roots are left unchanged. `output_dir` and `wandb_dir` are also localized when their absolute mount is absent or read-only. To force a different storage location, edit `data.dataset_dir` and `probe.dataset_roots.*` to existing writable paths before downloading.
+On the MedARC cluster, the checked-in `/data` and `/block` paths are the intended populated shared defaults. On a fresh clone, `prepare.py … download=True` rewrites any missing or empty checked-in data/probe roots to point into `nanopath/data/<name>`, preserving comments and formatting. It also moves `output_dir` and `wandb_dir` into `nanopath/data/` whenever a config's data roots are localized. The rewrite updates the config you pass plus the checked-in `configs/main.yaml` and `configs/smoke.yaml`, so running prepare on smoke first still leaves main directly runnable afterward. This happens even if the machine has a `/data` mount but lacks `/data/nanopath_parquet`. Populated shared roots are left unchanged. To force a different storage location, edit `data.dataset_dir`, `probe.dataset_roots.*`, `project.output_dir`, and `project.wandb_dir` to existing writable paths before downloading.
 
 **What `download=True` does**
 1. **TCGA tiles**: `huggingface_hub.snapshot_download` (filtered to `shard-*.parquet`) pulls the 200 parquet shards (~120 GB total, `{path: string, jpeg: binary}` rows with 64-row row groups) from [`medarc/nanopath`](https://huggingface.co/datasets/medarc/nanopath) into `data.dataset_dir`.
@@ -218,10 +218,10 @@ sbatch submit/train_1gpu.sbatch configs/main.yaml
 
 ## Outputs
 
-The `/data`- and `/block`-rooted defaults below are the MedARC cluster layout; `prepare.py … download=True` rewrites missing or empty data/probe defaults in the requested config plus `configs/{main,smoke}.yaml` to live under `nanopath/data/` instead, and then downloads there.
+The `/data`- and `/block`-rooted defaults below are the MedARC cluster layout; `prepare.py … download=True` rewrites missing or empty data/probe defaults in the requested config plus `configs/{main,smoke}.yaml` to live under `nanopath/data/` instead, and it localizes run outputs/W&B logs there too for those rewritten configs.
 
-- run outputs: `project.output_dir` (default is `/data/$USER/nanopath/main/...`). Final probe results log to `metrics.jsonl`.
-- wandb: `/data/$USER/nanopath/wandb`.
+- run outputs: `project.output_dir` (cluster default `/data/$USER/nanopath/main/...`; auto-localized default `nanopath/data/main/...`). Final probe results log to `metrics.jsonl`.
+- wandb: `project.wandb_dir` (cluster default `/data/$USER/nanopath/wandb`; auto-localized default `nanopath/data/wandb`).
 - parquet tile shards: `data.dataset_dir` (defaults to `/data/nanopath_parquet`).
 - probe datasets: `probe.dataset_roots` (defaults to shared `/block/...` and `/data/...` paths on the MedARC cluster).
 - DINOv2 backbone weights: `~/.cache/torch/hub/checkpoints/` for the selected `model.type`.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The script reads `summary.json` and `metrics.jsonl`, reviews `output_dir/labless
 
 `prepare.py` prepares the necessary data for pretraining and downstream probing. Flag `download=True` to fetch/prepare the configured datasets into the folders specified by the YAML; flag `download=False` to verify that all required paths are already populated.
 
-On the MedARC cluster, the checked-in `/data` and `/block` paths are the intended defaults. On a fresh clone with no such mounts, `prepare.py … download=True` rewrites those roots in place in the config you pass (data, probes, `output_dir`, `wandb_dir`) to point into `nanopath/data/<name>`, preserving all comments — so it just works with no manual YAML edits, and `train.py`/`probe.py` then read the corrected config unchanged. Only roots that are missing and whose `/data` or `/block` mount is absent or not writable get rewritten; the rewrite is idempotent and a no-op on the cluster. To point elsewhere, edit `data.dataset_dir` and the `probe.dataset_roots.*` paths to writable storage before downloading.
+On the MedARC cluster, the checked-in `/data` and `/block` paths are the intended populated shared defaults. On a fresh clone, `prepare.py … download=True` rewrites any missing or empty checked-in data/probe roots in the config you pass to point into `nanopath/data/<name>`, preserving comments and formatting. This happens even if the machine has a `/data` mount but lacks `/data/nanopath_parquet`, so a successful prepare run leaves the YAML directly runnable by `train.py`/`probe.py` with no manual path edits. Populated shared roots are left unchanged. `output_dir` and `wandb_dir` are also localized when their absolute mount is absent or read-only. To force a different storage location, edit `data.dataset_dir` and `probe.dataset_roots.*` to existing writable paths before downloading.
 
 **What `download=True` does**
 1. **TCGA tiles**: `huggingface_hub.snapshot_download` (filtered to `shard-*.parquet`) pulls the 200 parquet shards (~120 GB total, `{path: string, jpeg: binary}` rows with 64-row row groups) from [`medarc/nanopath`](https://huggingface.co/datasets/medarc/nanopath) into `data.dataset_dir`.
@@ -218,7 +218,7 @@ sbatch submit/train_1gpu.sbatch configs/main.yaml
 
 ## Outputs
 
-The `/data`- and `/block`-rooted defaults below are the MedARC cluster layout; on a fresh clone with neither mount, `prepare.py … download=True` rewrites these roots (data, probes, `output_dir`, `wandb_dir`) in the config to live under `nanopath/data/` instead.
+The `/data`- and `/block`-rooted defaults below are the MedARC cluster layout; `prepare.py … download=True` rewrites missing or empty data/probe defaults in the config to live under `nanopath/data/` instead, and then downloads there.
 
 - run outputs: `project.output_dir` (default is `/data/$USER/nanopath/main/...`). Final probe results log to `metrics.jsonl`.
 - wandb: `/data/$USER/nanopath/wandb`.

--- a/prepare.py
+++ b/prepare.py
@@ -1,5 +1,5 @@
-# Single data-prep entry point. Reads the YAML config the user passes in and
-# checks every path train.py will read:
+# Single data-prep entry point. Reads configs/main.yaml by default (or a
+# user-passed YAML config) and checks every path train.py will read:
 #   - data.dataset_dir/shard-NNNNN.parquet   (the 4M-tile dataset, sharded)
 #   - probe.dataset_roots[name] for each configured probe dataset
 #   - Meta's DINOv2 pretrained weights for cfg["model"]["type"] (torch.hub cache)
@@ -10,8 +10,9 @@
 # you want to regenerate the tile dataset from raw SVS files; see README.
 #
 # Run:
-#   python prepare.py <config.yaml> download=False  # verify only
-#   python prepare.py <config.yaml> download=True   # fetch what's missing
+#   python prepare.py download=False                    # verify configs/main.yaml
+#   python prepare.py download=True                     # fetch what's missing
+#   python prepare.py configs/smoke.yaml download=True  # override the default config
 #
 # `process_row`, `count_rows`, `select_rows`, `prepare_tiles`, and
 # `pack_from_jpeg_dir` are kept in this file so a contributor revising tile
@@ -766,15 +767,22 @@ def is_populated(name, p):
 
 
 def main():
-    usage = "usage: python prepare.py <config.yaml> download=True|download=False"
-    # Config path is required, must be a YAML.
-    if len(sys.argv) < 2 or not sys.argv[1].endswith((".yaml", ".yml")):
+    usage = "usage: python prepare.py [config.yaml] download=True|download=False"
+    args = sys.argv[1:]
+    # The download flag is required and must be exactly download=True or download=False.
+    if not args or args[-1] not in ("download=True", "download=False"):
         raise SystemExit(usage)
-    config_path = Path(sys.argv[1])
-    # download flag is required and must be exactly download=True or download=False.
-    if len(sys.argv) != 3 or sys.argv[2] not in ("download=True", "download=False"):
+    download = args[-1] == "download=True"
+    # Config path is optional; without one, prepare the canonical main recipe.
+    if len(args) == 1:
+        config_path = REPO_ROOT / "configs" / "main.yaml"
+    elif len(args) == 2 and args[0].endswith((".yaml", ".yml")):
+        config_path = Path(args[0])
+    else:
         raise SystemExit(usage)
-    download = sys.argv[2] == "download=True"
+    resolved_config_path = config_path.resolve()
+    config_label = str(resolved_config_path.relative_to(REPO_ROOT)) if resolved_config_path.is_relative_to(REPO_ROOT) else str(config_path)
+    prepare_cmd = "python prepare.py download=True" if len(args) == 1 else f"python prepare.py {config_label} download=True"
 
     # Off-cluster, correct the requested config plus the checked-in smoke/main
     # recipes before preparing, so subsequent train.py commands read the same
@@ -792,8 +800,8 @@ def main():
     elif not download:
         raise SystemExit(
             f"expected {NUM_SHARDS} parquet shards under {dataset_dir}, found {len(shards)}.\n"
-            f"Either fix data.dataset_dir in {config_path} to point at an existing prepared "
-            f"dataset, or rerun: python prepare.py {config_path} download=True"
+            f"Either fix data.dataset_dir in {config_label} to point at an existing prepared "
+            f"dataset, or rerun: {prepare_cmd}"
         )
     else:
         dataset_dir.mkdir(parents=True, exist_ok=True)
@@ -823,8 +831,8 @@ def main():
         for name, root in missing:
             lines.append(f"  probe/{name}: {root} is empty, missing, or stale for the current benchmark")
         lines.append(
-            f"Either fix probe.dataset_roots in {config_path} to point at existing populated "
-            f"paths, or rerun: python prepare.py {config_path} download=True"
+            f"Either fix probe.dataset_roots in {config_label} to point at existing populated "
+            f"paths, or rerun: {prepare_cmd}"
         )
         raise SystemExit("\n".join(lines))
 
@@ -843,7 +851,7 @@ def main():
     elif not download:
         raise SystemExit(
             f"Meta {cfg['model']['type']} pretrained weights missing at {weights_path}.\n"
-            f"Rerun: python prepare.py {config_path} download=True"
+            f"Rerun: {prepare_cmd}"
         )
     else:
         weights_dir.mkdir(parents=True, exist_ok=True)
@@ -859,8 +867,8 @@ def main():
     print(
         f"\nAll data ready: {n_shards} parquet shards at {dataset_dir}, {n_probes} probe datasets "
         f"({', '.join(cfg['probe']['dataset_roots'])}), and {cfg['model']['type']} weights at "
-        f"{weights_path}. Launch training with `python train.py {config_path}` or "
-        f"`sbatch submit/train_1gpu.sbatch {config_path}`.",
+        f"{weights_path}. Launch training with `python train.py {config_label}` or "
+        f"`sbatch submit/train_1gpu.sbatch {config_label}`.",
         flush=True,
     )
 

--- a/prepare.py
+++ b/prepare.py
@@ -701,6 +701,18 @@ def localize_config_file(config_path):
         print(f"[data] rewrote {len(changes)} missing/unusable root(s) in {config_path} to defaults under {REPO_ROOT / 'data'}.", flush=True)
 
 
+def localize_config_files(config_path):
+    # Smoke is the usual first command on a fresh clone, but users naturally
+    # train main next. Keep both checked-in recipes pointed at the same local
+    # downloaded data once either config triggers localization.
+    seen = set()
+    for path in [config_path, REPO_ROOT / "configs" / "main.yaml", REPO_ROOT / "configs" / "smoke.yaml"]:
+        path = path.resolve()
+        if path.exists() and path not in seen:
+            seen.add(path)
+            localize_config_file(path)
+
+
 # Flat dict of {label: expanded Path} for every data path declared in cfg.
 def get_paths(cfg):
     paths = {"data.dataset_dir": _resolve(cfg["data"]["dataset_dir"])}
@@ -762,10 +774,11 @@ def main():
         raise SystemExit(usage)
     download = sys.argv[2] == "download=True"
 
-    # Off-cluster, correct this config's cluster paths to repo-local defaults on
-    # disk before preparing, so the YAML matches where data actually lands.
+    # Off-cluster, correct the requested config plus the checked-in smoke/main
+    # recipes before preparing, so subsequent train.py commands read the same
+    # local paths that download=True populates.
     if download:
-        localize_config_file(config_path)
+        localize_config_files(config_path)
     cfg = yaml.safe_load(os.path.expandvars(config_path.read_text()))
     paths = get_paths(cfg)
     dataset_dir = paths["data.dataset_dir"]

--- a/prepare.py
+++ b/prepare.py
@@ -674,13 +674,15 @@ def _local_data_root(s):
     return str(s)
 
 
-# Output/log roots are allowed on writable /data, but still need localizing when
-# the configured absolute mount is absent or read-only.
-def _local_output_root(s):
+# Output/log roots follow repo-local data roots when prepare had to localize a
+# config, otherwise they stay on writable shared /data for MedARC runs.
+def _local_output_root(s, force=False):
     p = _resolve(s)
     mount = Path(*p.parts[:2]) if p.is_absolute() and len(p.parts) > 1 else p
-    if p.is_absolute() and not p.exists() and (not mount.exists() or not os.access(mount, os.W_OK)):
-        return str(REPO_ROOT / "data" / p.name)
+    if force or (p.is_absolute() and not p.exists() and (not mount.exists() or not os.access(mount, os.W_OK))):
+        parts = list(p.parts)
+        tail = parts[parts.index("nanopath") + 1:] if "nanopath" in parts else [p.name]
+        return str(REPO_ROOT / "data" / Path(*tail))
     return str(s)
 
 
@@ -693,7 +695,7 @@ def localize_config_file(config_path):
     data_roots = [cfg["data"]["dataset_dir"], *cfg["probe"]["dataset_roots"].values()]
     output_roots = [cfg["project"]["output_dir"], cfg["project"]["wandb_dir"]]
     changes = {v: nv for v in data_roots if (nv := _local_data_root(v)) != v}
-    changes.update({v: nv for v in output_roots if (nv := _local_output_root(v)) != v})
+    changes.update({v: nv for v in output_roots if (nv := _local_output_root(v, force=bool(changes))) != v})
     for old, new in changes.items():
         raw = raw.replace(f": {old}", f": {new}")
     if changes:

--- a/prepare.py
+++ b/prepare.py
@@ -664,11 +664,19 @@ def _resolve(s):
     return Path(os.path.expanduser(os.path.expandvars(str(s))))
 
 
-# Off-cluster default: a configured absolute path that is absent and whose mount
-# root (e.g. /data or /block) is missing or not writable means a fresh clone
-# cannot use the MedARC path. Retarget by basename into repo-local data/ so setup
-# works without YAML edits. Existing paths are returned unchanged.
-def _localize(s):
+# Missing checked-in /data and /block dataset defaults are shared-cluster paths,
+# not portable user choices. Retarget empty/missing ones into repo-local data/
+# so `prepare.py ... download=True` makes a fresh clone runnable by itself.
+def _local_data_root(s):
+    p = _resolve(s)
+    if p.is_absolute() and len(p.parts) > 1 and p.parts[1] in {"data", "block"} and (not p.is_dir() or not any(p.iterdir())):
+        return str(REPO_ROOT / "data" / p.name)
+    return str(s)
+
+
+# Output/log roots are allowed on writable /data, but still need localizing when
+# the configured absolute mount is absent or read-only.
+def _local_output_root(s):
     p = _resolve(s)
     mount = Path(*p.parts[:2]) if p.is_absolute() and len(p.parts) > 1 else p
     if p.is_absolute() and not p.exists() and (not mount.exists() or not os.access(mount, os.W_OK)):
@@ -676,22 +684,21 @@ def _localize(s):
     return str(s)
 
 
-# Off-cluster default: a fresh clone with no /data or /block mount can't use the
-# checked-in cluster paths, so rewrite them in place to point into repo-local
-# data/ (by basename). Surgical replacement on the raw text keeps every
-# comment/format intact and only touches values that actually redirect, so the
-# YAML itself becomes the source of truth that train.py/probe.py read unchanged.
-# Idempotent, and a no-op on the cluster where the paths/mounts already exist.
+# Rewrite missing portable defaults in place before downloading. Surgical text
+# replacement preserves comments and formatting, so the YAML remains the source
+# of truth that train.py/probe.py read unchanged after preparation.
 def localize_config_file(config_path):
     raw = config_path.read_text()
     cfg = yaml.safe_load(raw)
-    roots = [cfg["data"]["dataset_dir"], *cfg["probe"]["dataset_roots"].values(), cfg["project"]["output_dir"], cfg["project"]["wandb_dir"]]
-    changes = {v: nv for v in roots if (nv := _localize(v)) != v}
+    data_roots = [cfg["data"]["dataset_dir"], *cfg["probe"]["dataset_roots"].values()]
+    output_roots = [cfg["project"]["output_dir"], cfg["project"]["wandb_dir"]]
+    changes = {v: nv for v in data_roots if (nv := _local_data_root(v)) != v}
+    changes.update({v: nv for v in output_roots if (nv := _local_output_root(v)) != v})
     for old, new in changes.items():
         raw = raw.replace(f": {old}", f": {new}")
     if changes:
         config_path.write_text(raw)
-        print(f"[data] no /data or /block mount found; rewrote {len(changes)} root(s) in {config_path} to defaults under {REPO_ROOT / 'data'}.", flush=True)
+        print(f"[data] rewrote {len(changes)} missing/unusable root(s) in {config_path} to defaults under {REPO_ROOT / 'data'}.", flush=True)
 
 
 # Flat dict of {label: expanded Path} for every data path declared in cfg.


### PR DESCRIPTION
## Summary
- Clarify in the main README that Labless submissions use GitHub's no-scope device sign-in flow, with no separate Labless password or PR required for a leaderboard claim.
- Document the end-to-end submission pipeline: train a completed full run, verify `summary.json`, `metrics.jsonl`, and `labless_source/`, run the submitter, complete browser sign-in, and wait for maintainer validation.
- Make `prepare.py download=True` more automatic for fresh clones: missing or empty checked-in `/data` and `/block` data/probe roots are rewritten into repo-local `nanopath/data/<name>` even when a `/data` mount exists but lacks `/data/nanopath_parquet`.
- Localize the selected config plus checked-in `configs/main.yaml` and `configs/smoke.yaml` together, so a single prepare run leaves both smoke and main runnable against the same downloaded local data.
- Default `prepare.py` to `configs/main.yaml`, while still allowing explicit overrides like `python prepare.py configs/smoke.yaml download=True`.
- When data roots are localized, also rewrite `project.output_dir` and `project.wandb_dir` into repo-local defaults such as `nanopath/data/main/default`, `nanopath/data/main/smoke`, and `nanopath/data/wandb`.
- Leave populated shared cluster roots untouched.

## Validation
- `python -m py_compile prepare.py`
- `git diff --check`
- `python prepare.py download=False`
- `python prepare.py configs/smoke.yaml download=False`
- Invalid usage check: `python prepare.py configs/smoke.yaml` prints `usage: python prepare.py [config.yaml] download=True|download=False`.
- Throwaway config test: missing `/data/nanopath_parquet`, `/block/eva-data/bracs`, and `/data/CPTAC-PDA` roots rewrite to repo-local `data/...` paths before download.
- Fake fresh-clone config tree test: running localization on `smoke.yaml` rewrites both `smoke.yaml` and `main.yaml`, including data roots, `output_dir`, and `wandb_dir`.
- Default fresh-clone simulation: `python prepare.py download=True` selects `configs/main.yaml` and rewrites both `main.yaml` and `smoke.yaml` into repo-local data/output/W&B paths.
- Real cluster config copy test: populated shared roots produce no rewrite.
