### PR TITLE
[chore] Fix eta calculation

### DIFF
--- a/train.py
+++ b/train.py
@@ -648,6 +648,8 @@ def main():
                 # Atomic rename keeps the previous good latest.pt intact if a
                 # kill lands mid-save.
                 save_latest_checkpoint(completed_step)
+                last_console_step, last_console_monotonic = completed_step, time.monotonic()
+                last_time, last_examples, last_visible_patch_presentations, last_train_flops = time.time(), examples_seen, visible_patch_presentations, train_flops
             # Probe at intermediate sample milestones (probe.count > 1); the final probe
             # always runs after the loop exits, regardless of milestones.
             maybe_run_probe(completed_step)
@@ -658,6 +660,8 @@ def main():
                     handle.write(json.dumps(val_log) + "\n")
                 wandb_run.log({f"val/{k}": v for k, v in val.items()}, step=completed_step)
                 print(f"{console_prefix()} Validation  [{completed_step}]  total: {val['total']:.4f}  dino: {val['dino']:.4f}  ibot: {val['ibot']:.4f}  kde: {val['kde']:.4f}", flush=True)
+                last_console_step, last_console_monotonic = completed_step, time.monotonic()
+                last_time, last_examples, last_visible_patch_presentations, last_train_flops = time.time(), examples_seen, visible_patch_presentations, train_flops
             step = completed_step
             data_wait_started_at = time.monotonic()
             if train_flops >= max_train_flops or examples_seen + batch_size > max_train_samples:

--- a/train.py
+++ b/train.py
@@ -648,8 +648,6 @@ def main():
                 # Atomic rename keeps the previous good latest.pt intact if a
                 # kill lands mid-save.
                 save_latest_checkpoint(completed_step)
-                last_console_step, last_console_monotonic = completed_step, time.monotonic()
-                last_time, last_examples, last_visible_patch_presentations, last_train_flops = time.time(), examples_seen, visible_patch_presentations, train_flops
             # Probe at intermediate sample milestones (probe.count > 1); the final probe
             # always runs after the loop exits, regardless of milestones.
             maybe_run_probe(completed_step)
@@ -660,6 +658,7 @@ def main():
                     handle.write(json.dumps(val_log) + "\n")
                 wandb_run.log({f"val/{k}": v for k, v in val.items()}, step=completed_step)
                 print(f"{console_prefix()} Validation  [{completed_step}]  total: {val['total']:.4f}  dino: {val['dino']:.4f}  ibot: {val['ibot']:.4f}  kde: {val['kde']:.4f}", flush=True)
+                # Reset rate clocks after validation so the next train log is train-rate only.
                 last_console_step, last_console_monotonic = completed_step, time.monotonic()
                 last_time, last_examples, last_visible_patch_presentations, last_train_flops = time.time(), examples_seen, visible_patch_presentations, train_flops
             step = completed_step


### PR DESCRIPTION
**Summary**

Fixes inflated training ETA and throughput logs immediately after validation.

**Issue**

`Training` log ETA is computed from the wall-clock gap since the previous training log. When validation runs between two training logs, that validation time gets included in the next `console_gap_ms`, making the next `eta`, `gap`, and throughput metrics look much worse than actual training speed.

Here's the visual:
<img width="966" height="438" alt="image" src="https://github.com/user-attachments/assets/29929ee9-aa37-4e0b-9647-138bf14a527a" />
Also flops/s look too low:
<img width="956" height="405" alt="image" src="https://github.com/user-attachments/assets/2d97d38d-2521-48f6-b72c-bfe83dfca70b" />


**Fix**

After each validation pass, reset the training-rate timers so the next `Training` log reports train-step rate only, instead of including validation wall time.

Now the estimations are more accurate:
<img width="971" height="415" alt="image" src="https://github.com/user-attachments/assets/fc504cd7-f795-4cc2-9787-44b2baae8185" />

<img width="947" height="397" alt="image" src="https://github.com/user-attachments/assets/d648e59f-be38-4624-9dc9-c923129e4558" />


