### PR TITLE
Credit Labless contributors for Pathway, GuruTurbo, and robust-norm

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ The `main` branch uses the `lr-and-curation` recipe. Model links below select th
 
 | # | Description | final score | classification | segmentation | progression | mutation | survival | robustness | Contributors |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---|
-| 1 | [GuruTurbo1.0](https://github.com/MedARC-AI/nanopath/tree/GuruTurbo1.0) | **0.6597** | 0.7518 | 0.6030 | 0.6365 | 0.6289 | 0.6301 | 0.6046 | @aajing |
-| 2 | [pathway-tta](https://github.com/MedARC-AI/nanopath/tree/pathway-tta) | 0.6491 | 0.7557 | 0.6020 | 0.5993 | 0.6128 | 0.6242 | 0.5896 | @achi2023 |
+| 1 | [GuruTurbo1.0](https://github.com/MedARC-AI/nanopath/tree/GuruTurbo1.0) | **0.6597** | 0.7518 | 0.6030 | 0.6365 | 0.6289 | 0.6301 | 0.6046 | [@aajing](https://github.com/aajing) |
+| 2 | [pathway-tta](https://github.com/MedARC-AI/nanopath/tree/pathway-tta) | 0.6491 | 0.7557 | 0.6020 | 0.5993 | 0.6128 | 0.6242 | 0.5896 | [@achi2023](https://github.com/achi2023) |
 | 3 | [jepa-fino](https://github.com/MedARC-AI/nanopath/tree/jepa-fino-v2) | 0.6483 | 0.7384 | 0.6016 | 0.6010 | 0.6190 | 0.6210 | 0.6132 | @ml-and-ml |
-| 4 | [robust-norm](https://github.com/MedARC-AI/nanopath/tree/robust-norm-v2) | 0.6465 | 0.7507 | 0.6024 | 0.6073 | 0.5885 | 0.6010 | 0.6088 | @anishdulal |
+| 4 | [robust-norm](https://github.com/MedARC-AI/nanopath/tree/robust-norm-v2) | 0.6465 | 0.7507 | 0.6024 | 0.6073 | 0.5885 | 0.6010 | 0.6088 | [@anishdulal](https://github.com/anishdulal) |
 | 5 | I-JEPA contig patch | 0.6463 | 0.7219 | 0.5993 | 0.6238 | 0.6148 | 0.6172 | 0.6143 | @NimaAsh |
 | 6 | block-strided-cls | 0.6448 | 0.7477 | 0.6039 | 0.5738 | 0.6066 | 0.6335 | 0.6069 | @RyanKim17920 |
 | 7 | [lr-and-curation](https://github.com/MedARC-AI/nanopath) | 0.6349 | 0.7048 | 0.5940 | 0.6045 | 0.6025 | 0.6199 | 0.6114 | @nevasini1 |


### PR DESCRIPTION
The model table already names the original contributors, but its commits did not carry GitHub co-author credit. This follow-up to [the model-table update](https://github.com/MedARC-AI/nanopath/commit/13abb46bafd46d50144eb61536a9bd909fef1023), which was committed directly to main, links their profiles and records all three as co-authors using their GitHub no-reply addresses.

| Recipe | Verified Labless contributor | Source run | Branch attribution |
|---|---|---|---|
| pathway-tta | [@achi2023](https://github.com/achi2023) | [Original submission](https://labless.dev/runs/run_sub_be11dc9877) | [Credit commit](https://github.com/MedARC-AI/nanopath/commit/3c4edb87738b82fa975e408c37630e75615997cd) |
| GuruTurbo1.0 | [@aajing](https://github.com/aajing) | [Original submission](https://labless.dev/runs/run_sub_bf33fffa9d) | [Credit commit](https://github.com/MedARC-AI/nanopath/commit/76ae560379924b3ac35cedbd68751230521ae0e2) |
| robust-norm-v2 | [@anishdulal](https://github.com/anishdulal) | [Validated submission](https://labless.dev/runs/run_v2_sub_16b156161d) | [Credit commit](https://github.com/MedARC-AI/nanopath/commit/3f1685fa2d89ff895116f0ffc7d7d882bafda030) |

Validation: compared identities with the public Labless run records and GitHub user API; GitHub GraphQL resolves each branch co-author and all three shared co-authors to the intended accounts. The PR changes only three contributor links in README.md; `git diff --check` passes.

Additional model contributor: [Hassan Muhammad (@ml-and-ml)](https://github.com/ml-and-ml) contributed JEPA-FINO, verified by the [original Labless submission](https://labless.dev/runs/run_sub_3cd4be1e0c) and [validated run](https://labless.dev/runs/run_v2_sub_1879d32919). His GitHub co-author credit is recorded in merged follow-up #17 and the [jepa-fino-v2 branch commit](https://github.com/MedARC-AI/nanopath/commit/ce4f5184eea040b8db3e3a93ba60e598ef1abc8b).
