### PR TITLE
Credit ml-and-ml for JEPA-FINO

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The `main` branch uses the `lr-and-curation` recipe. Model links below select th
 |---|---|---:|---:|---:|---:|---:|---:|---:|---|
 | 1 | [GuruTurbo1.0](https://github.com/MedARC-AI/nanopath/tree/GuruTurbo1.0) | **0.6597** | 0.7518 | 0.6030 | 0.6365 | 0.6289 | 0.6301 | 0.6046 | [@aajing](https://github.com/aajing) |
 | 2 | [pathway-tta](https://github.com/MedARC-AI/nanopath/tree/pathway-tta) | 0.6491 | 0.7557 | 0.6020 | 0.5993 | 0.6128 | 0.6242 | 0.5896 | [@achi2023](https://github.com/achi2023) |
-| 3 | [jepa-fino](https://github.com/MedARC-AI/nanopath/tree/jepa-fino-v2) | 0.6483 | 0.7384 | 0.6016 | 0.6010 | 0.6190 | 0.6210 | 0.6132 | @ml-and-ml |
+| 3 | [jepa-fino](https://github.com/MedARC-AI/nanopath/tree/jepa-fino-v2) | 0.6483 | 0.7384 | 0.6016 | 0.6010 | 0.6190 | 0.6210 | 0.6132 | [@ml-and-ml](https://github.com/ml-and-ml) |
 | 4 | [robust-norm](https://github.com/MedARC-AI/nanopath/tree/robust-norm-v2) | 0.6465 | 0.7507 | 0.6024 | 0.6073 | 0.5885 | 0.6010 | 0.6088 | [@anishdulal](https://github.com/anishdulal) |
 | 5 | I-JEPA contig patch | 0.6463 | 0.7219 | 0.5993 | 0.6238 | 0.6148 | 0.6172 | 0.6143 | @NimaAsh |
 | 6 | block-strided-cls | 0.6448 | 0.7477 | 0.6039 | 0.5738 | 0.6066 | 0.6335 | 0.6069 | @RyanKim17920 |


### PR DESCRIPTION
Adds the omitted JEPA-FINO contributor, [Hassan Muhammad (@ml-and-ml)](https://github.com/ml-and-ml), to the attribution work in #16. Links his profile in the model table and records him as a commit co-author using his GitHub no-reply address.

Identity is verified against the [original jf-hed07 submission](https://labless.dev/runs/run_sub_3cd4be1e0c) and [validated jepa-fino-s2026 run](https://labless.dev/runs/run_v2_sub_1879d32919). The [jepa-fino-v2 branch attribution commit](https://github.com/MedARC-AI/nanopath/commit/ce4f5184eea040b8db3e3a93ba60e598ef1abc8b) also credits him.

Validation: GitHub GraphQL recognizes @ml-and-ml as co-author of both commits. Only one README profile link changes in this PR; `git diff --check` passes.
