### PR TITLE
Improve nanopath training speed by 2.3× to 3.8×

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ RUN_DIR=$PWD/data/main/my-run
 # or directly on a GPU machine: python train.py configs/main.yaml output_dir=$RUN_DIR
 ```
 
-`pyproject.toml` pins PyTorch 2.8.0 and torchvision 0.23.0 against the CUDA 12.9 wheel index. Ordinary `uv sync` installs Pillow without Kornia. For GPU augmentation, run `uv sync --extra gpu` to install Kornia 0.8.3. If your GPU/driver needs a different CUDA build, edit the `torch` and `torchvision` lines in `pyproject.toml` before `uv sync`.
+`pyproject.toml` pins PyTorch 2.8.0 and torchvision 0.23.0 against the CUDA 12.9 wheel index. Ordinary `uv sync` installs Pillow without Kornia. For GPU augmentation, run `uv sync --extra gpuaug` to install Kornia 0.8.3. If your GPU/driver needs a different CUDA build, edit the `torch` and `torchvision` lines in `pyproject.toml` before `uv sync`.
 
 A successful model training prints periodic train lines, appends metrics to `metrics.jsonl`, and writes the final comparison artifact to `summary.json`. `configs/smoke.yaml` is simply meant to pretrain briefly and then run the fixed downstream probe suite to ensure everything works without errors.
 
@@ -247,9 +247,9 @@ The three performance switches in `train` are independent and default to `false`
 | `fused_adamw` | Enables native AdamW fusion |
 | `gpu_augment` | Applies stain jitter, color changes, blur, and normalization on the GPU |
 
-All loaders crop, resize, and flip PIL images on the CPU. The CPU tail receives float32 crops. The GPU tail receives uint8 crops and requires `uv sync --extra gpu`. With `compile: false`, the GPU tail runs eagerly.
+All loaders crop, resize, and flip PIL images on the CPU. The CPU tail receives float32 crops. The GPU tail receives uint8 crops and requires `uv sync --extra gpuaug`. With `compile: false`, the GPU tail runs eagerly.
 
-For the fastest tested recipe, use the isolated SIMD installation below. Change these values in your YAML config:
+For the fastest tested recipe, install the SIMD extra below. Change these values in your YAML config:
 
 ```yaml
 train:
@@ -265,23 +265,17 @@ The first compiled run builds kernels for the crop sizes. Compiler caches live b
 
 PIL geometry changes interpolation from the older tensor loader. GPU augmentation also changes grayscale coefficients and random-number consumption. These changes do not preserve identical stochastic trajectories. The performance switches remain disabled pending full-protocol quality validation.
 
-Pillow-SIMD is an optional pretraining installation. The tested AVX2 build requires an x86 CPU with AVX2, a compatible Python ABI, and libjpeg/zlib development headers and libraries. The default environment keeps ordinary Pillow. Both distributions provide `PIL`, so a uv extra cannot isolate them.
-
-On a compatible allocated node, choose an empty target directory and build the tested version without cached wheels:
+Pillow-SIMD requires an x86 CPU with AVX2 and libjpeg/zlib development headers and libraries. On a compatible allocated node, install both optional extras:
 
 ```bash
-SIMD_DIR=/data/$USER/nanopath/pillow-simd-o3
-CC='cc -mavx2' CFLAGS='-O3 -DNDEBUG' uv pip install \
-  --python .venv/bin/python --target "$SIMD_DIR" --no-cache --no-binary pillow-simd \
-  --verbose --no-deps pillow-simd==9.5.0.post2
-PYTHONPATH="$SIMD_DIR" python -c "import PIL; from PIL import features; print(PIL.__version__, PIL.__file__, features.check_feature('libjpeg_turbo'))"
-PYTHONPATH="$SIMD_DIR" ./submit/train_1gpu.sbatch configs/main.yaml
-# On an allocated GPU, use the same override with python train.py configs/main.yaml.
+uv sync --extra gpuaug --extra simd --no-install-package pillow
+python -c "import PIL; from PIL import features; print(PIL.__version__, PIL.__file__, features.check_feature('libjpeg_turbo'))"
+./submit/train_1gpu.sbatch configs/main.yaml
 ```
 
-The [tested cluster build recipe](/data/benjamin/nanopath/dataloader-bench/jitter-fixed/jitter-fixed.sbatch) supplies site-specific include and library paths. Preserve `-O3 -DNDEBUG` when adding include flags. The launcher passes `PYTHONPATH` to pretraining without changing Labless behavior. Startup logs and W&B config record the effective Pillow version and import path.
+Omit `--extra gpuaug` if you only want SIMD. Keep `--no-install-package pillow` whenever you select `simd`: both distributions provide `PIL`. The build uses `-mavx2` and `-O3 -DNDEBUG` from `pyproject.toml`; uv tracks these settings in its build cache. Cluster installations may need site-specific header and library paths.
 
-Remove the `PYTHONPATH` override from the invocation to return to ordinary Pillow. The probe subprocess replaces `PYTHONPATH` with the repository path, so downstream probes retain ordinary Pillow. This overlay targets pretraining only.
+Run `uv sync` (or `uv sync --extra gpuaug`) to restore ordinary Pillow. The selected Pillow backend applies to training and probes. Startup logs and W&B config record its version and import path.
 
 The checked-in `#SBATCH` lines are specific to our MedARC cluster. On another SLURM cluster, edit those header lines once to match your queue, or run `python train.py ...` directly on an allocated GPU.
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Compilation adds startup time on the first run. Later runs can reuse cached comp
 
 #### Installation
 
-Pillow-SIMD requires an x86 CPU with AVX2 and libjpeg/zlib development headers and libraries.
+Pillow-SIMD requires an x86 CPU with AVX2 and libjpeg, zlib, and libtiff development headers and libraries.
 
 ```bash
 uv sync --extra gpuaug --extra simd --no-install-package pillow

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ RUN_DIR=$PWD/data/main/my-run
 # or directly on a GPU machine: python train.py configs/main.yaml output_dir=$RUN_DIR
 ```
 
-`pyproject.toml` pins `torch` / `torchvision` against the CUDA 12.9 wheel index. If your GPU/driver needs a different CUDA build, edit the `torch` and `torchvision` lines in `pyproject.toml` before `uv sync`.
+`pyproject.toml` pins PyTorch 2.8.0 and torchvision 0.23.0 against the CUDA 12.9 wheel index. Ordinary `uv sync` installs Pillow without Kornia. For GPU augmentation, run `uv sync --extra gpu` to install Kornia 0.8.3. If your GPU/driver needs a different CUDA build, edit the `torch` and `torchvision` lines in `pyproject.toml` before `uv sync`.
 
 A successful model training prints periodic train lines, appends metrics to `metrics.jsonl`, and writes the final comparison artifact to `summary.json`. `configs/smoke.yaml` is simply meant to pretrain briefly and then run the fixed downstream probe suite to ensure everything works without errors.
 
@@ -238,6 +238,50 @@ Full main `nanopath` recipe:
 ```
 
 `submit/train_1gpu.sbatch` is a prompt-aware launcher when run directly: it collects Labless run name, notes, and GitHub device login before submitting itself to SLURM, then auto-submits eligible completed full runs. Calling `sbatch submit/train_1gpu.sbatch ...` bypasses that prompt and trains without auto-submit. `configs/main.yaml` is sized for an 80 GB H100 at `train.batch_size: 128`. On smaller cards you can set `train.activation_checkpointing: true` and lower `train.batch_size` if you OOM.
+
+The three performance switches in `train` are independent and default to `false`:
+
+| Config key | Effect when true |
+|---|---|
+| `compile` | Compiles backbones, heads, losses, and the GPU augmentation tail |
+| `fused_adamw` | Enables native AdamW fusion |
+| `gpu_augment` | Applies stain jitter, color changes, blur, and normalization on the GPU |
+
+All loaders crop, resize, and flip PIL images on the CPU. The CPU tail receives float32 crops. The GPU tail receives uint8 crops and requires `uv sync --extra gpu`. With `compile: false`, the GPU tail runs eagerly.
+
+For the fastest tested recipe, use the isolated SIMD installation below. Change these values in your YAML config:
+
+```yaml
+train:
+  compile: true
+  fused_adamw: true
+  gpu_augment: true
+  num_workers: 8
+```
+
+Keep the other `train` values in your config. Add explicit `compile`, `fused_adamw`, and `gpu_augment` keys to older external YAML copies. Checkpoint weight keys stay unchanged. Resume uses the fused backend from the requested config.
+
+The first compiled run builds kernels for the crop sizes. Compiler caches live beside `project.wandb_dir`. Standard `TORCHINDUCTOR_CACHE_DIR` and `TRITON_CACHE_DIR` values override these paths. Compilation adds startup time.
+
+PIL geometry changes interpolation from the older tensor loader. GPU augmentation also changes grayscale coefficients and random-number consumption. These changes do not preserve identical stochastic trajectories. The performance switches remain disabled pending full-protocol quality validation.
+
+Pillow-SIMD is an optional pretraining installation. The tested AVX2 build requires an x86 CPU with AVX2, a compatible Python ABI, and libjpeg/zlib development headers and libraries. The default environment keeps ordinary Pillow. Both distributions provide `PIL`, so a uv extra cannot isolate them.
+
+On a compatible allocated node, choose an empty target directory and build the tested version without cached wheels:
+
+```bash
+SIMD_DIR=/data/$USER/nanopath/pillow-simd-o3
+CC='cc -mavx2' CFLAGS='-O3 -DNDEBUG' uv pip install \
+  --python .venv/bin/python --target "$SIMD_DIR" --no-cache --no-binary pillow-simd \
+  --verbose --no-deps pillow-simd==9.5.0.post2
+PYTHONPATH="$SIMD_DIR" python -c "import PIL; from PIL import features; print(PIL.__version__, PIL.__file__, features.check_feature('libjpeg_turbo'))"
+PYTHONPATH="$SIMD_DIR" ./submit/train_1gpu.sbatch configs/main.yaml
+# On an allocated GPU, use the same override with python train.py configs/main.yaml.
+```
+
+The [tested cluster build recipe](/data/benjamin/nanopath/dataloader-bench/jitter-fixed/jitter-fixed.sbatch) supplies site-specific include and library paths. Preserve `-O3 -DNDEBUG` when adding include flags. The launcher passes `PYTHONPATH` to pretraining without changing Labless behavior. Startup logs and W&B config record the effective Pillow version and import path.
+
+Remove the `PYTHONPATH` override from the invocation to return to ordinary Pillow. The probe subprocess replaces `PYTHONPATH` with the repository path, so downstream probes retain ordinary Pillow. This overlay targets pretraining only.
 
 The checked-in `#SBATCH` lines are specific to our MedARC cluster. On another SLURM cluster, edit those header lines once to match your queue, or run `python train.py ...` directly on an allocated GPU.
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ Install [uv](https://docs.astral.sh/uv/) first if you don't have it, then:
 
 ```bash
 git clone https://github.com/MedARC-AI/nanopath.git && cd nanopath
-uv sync
-source .venv/bin/activate
+uv sync && source .venv/bin/activate
 wandb login  # or: export WANDB_MODE=offline before launching noninteractive SLURM jobs
 
 # download pretraining & probe datasets & DINOv2 pretrained ckpt

--- a/README.md
+++ b/README.md
@@ -239,17 +239,31 @@ Full main `nanopath` recipe:
 
 `submit/train_1gpu.sbatch` is a prompt-aware launcher when run directly: it collects Labless run name, notes, and GitHub device login before submitting itself to SLURM, then auto-submits eligible completed full runs. Calling `sbatch submit/train_1gpu.sbatch ...` bypasses that prompt and trains without auto-submit. `configs/main.yaml` is sized for an 80 GB H100 at `train.batch_size: 128`. On smaller cards you can set `train.activation_checkpointing: true` and lower `train.batch_size` if you OOM.
 
-The three performance switches in `train` are independent and default to `false`:
+The checked-in `#SBATCH` lines are specific to our MedARC cluster. On another SLURM cluster, edit those header lines once to match your queue, or run `python train.py ...` directly on an allocated GPU.
+
+### Performance
+
+nonpath has three performance flags in `train`, which are independent and default to `false`:
 
 | Config key | Effect when true |
 |---|---|
-| `compile` | Compiles backbones, heads, losses, and the GPU augmentation tail |
-| `fused_adamw` | Enables native AdamW fusion |
+| `compile` | Compiles model backbones, heads, losses, and the GPU augmentations if enabled |
+| `fused_adamw` | Use PyTorch's fused AdamW |
 | `gpu_augment` | Applies stain jitter, color changes, blur, and normalization on the GPU |
 
-All loaders crop, resize, and flip PIL images on the CPU. The CPU tail receives float32 crops. The GPU tail receives uint8 crops and requires `uv sync --extra gpuaug`. With `compile: false`, the GPU tail runs eagerly.
+All loaders crop, resize, and flip PIL images on the CPU. The CPU tail receives float32 crops. The GPU augmentations pipeline requires `uv sync --extra gpuaug`. With `compile: false`, GPU augmentations run eagerly.
 
-For the fastest tested recipe, install the SIMD extra below. Change these values in your YAML config:
+Training throughput from 15-minute trials after warmup, each using one H100 at batch size 128:
+
+| Augmentation | Compile + fused AdamW | Tiles/second |
+|---|---|---:|
+| Original CPU | Off | ~300 |
+| Pillow-SIMD | On | ~350 |
+| Pillow + GPU augmentations | Off | ~420 |
+| Pillow + GPU augmentations | On | ~660 |
+| Pillow-SIMD + GPU augmentations | On | ~690 |
+
+For the fastest tested recipe, install the SIMD and GPU augmentation extras below and enable these flags in your YAML config:
 
 ```yaml
 train:
@@ -259,25 +273,20 @@ train:
   num_workers: 8
 ```
 
-Keep the other `train` values in your config. Add explicit `compile`, `fused_adamw`, and `gpu_augment` keys to older external YAML copies. Checkpoint weight keys stay unchanged. Resume uses the fused backend from the requested config.
+Compilation adds startup time on the first run. Later runs can reuse cached compiled code. Compiler cache defaults to beside `project.wandb_dir` with `TORCHINDUCTOR_CACHE_DIR` and `TRITON_CACHE_DIR` values overriding these paths.
 
-The first compiled run builds kernels for the crop sizes. Compiler caches live beside `project.wandb_dir`. Standard `TORCHINDUCTOR_CACHE_DIR` and `TRITON_CACHE_DIR` values override these paths. Compilation adds startup time.
+#### Installation
 
-PIL geometry changes interpolation from the older tensor loader. GPU augmentation also changes grayscale coefficients and random-number consumption. These changes do not preserve identical stochastic trajectories. The performance switches remain disabled pending full-protocol quality validation.
-
-Pillow-SIMD requires an x86 CPU with AVX2 and libjpeg/zlib development headers and libraries. On a compatible allocated node, install both optional extras:
+Pillow-SIMD requires an x86 CPU with AVX2 and libjpeg/zlib development headers and libraries.
 
 ```bash
 uv sync --extra gpuaug --extra simd --no-install-package pillow
-python -c "import PIL; from PIL import features; print(PIL.__version__, PIL.__file__, features.check_feature('libjpeg_turbo'))"
 ./submit/train_1gpu.sbatch configs/main.yaml
 ```
 
 Omit `--extra gpuaug` if you only want SIMD. Keep `--no-install-package pillow` whenever you select `simd`: both distributions provide `PIL`. The build uses `-mavx2` and `-O3 -DNDEBUG` from `pyproject.toml`; uv tracks these settings in its build cache. Cluster installations may need site-specific header and library paths.
 
 Run `uv sync` (or `uv sync --extra gpuaug`) to restore ordinary Pillow. The selected Pillow backend applies to training and probes. Startup logs and W&B config record its version and import path.
-
-The checked-in `#SBATCH` lines are specific to our MedARC cluster. On another SLURM cluster, edit those header lines once to match your queue, or run `python train.py ...` directly on an allocated GPU.
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Install [uv](https://docs.astral.sh/uv/) first if you don't have it, then:
 
 ```bash
 git clone https://github.com/MedARC-AI/nanopath.git && cd nanopath
-uv sync && source .venv/bin/activate
+uv sync --extra gpuaug --extra simd --no-install-package pillow
+source .venv/bin/activate
 wandb login  # or: export WANDB_MODE=offline before launching noninteractive SLURM jobs
 
 # download pretraining & probe datasets & DINOv2 pretrained ckpt
@@ -243,7 +244,7 @@ The checked-in `#SBATCH` lines are specific to our MedARC cluster. On another SL
 
 ### Performance
 
-nonpath has three performance flags in `train`, which are independent and default to `false`:
+Nanopath enables these three independent performance flags in the main and smoke configs:
 
 | Config key | Effect when true |
 |---|---|
@@ -263,7 +264,7 @@ Training throughput from 15-minute trials after warmup, each using one H100 at b
 | Pillow + GPU augmentations | On | ~660 |
 | Pillow-SIMD + GPU augmentations | On | ~690 |
 
-For the fastest tested recipe, install the SIMD and GPU augmentation extras below and enable these flags in your YAML config:
+The main and smoke configs use the tested fast recipe:
 
 ```yaml
 train:
@@ -286,7 +287,7 @@ uv sync --extra gpuaug --extra simd --no-install-package pillow
 
 Omit `--extra gpuaug` if you only want SIMD. Keep `--no-install-package pillow` whenever you select `simd`: both distributions provide `PIL`. The build uses `-mavx2` and `-O3 -DNDEBUG` from `pyproject.toml`; uv tracks these settings in its build cache. Cluster installations may need site-specific header and library paths.
 
-Run `uv sync` (or `uv sync --extra gpuaug`) to restore ordinary Pillow. The selected Pillow backend applies to training and probes. Startup logs and W&B config record its version and import path.
+Run `uv sync --extra gpuaug` to use ordinary Pillow with the default GPU augmentation config. For CPU augmentation, set `train.gpu_augment: false` and run `uv sync`. The selected Pillow backend applies to training and probes. Startup logs and W&B config record its version and import path.
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Install [uv](https://docs.astral.sh/uv/) first if you don't have it, then:
 
 ```bash
 git clone https://github.com/MedARC-AI/nanopath.git && cd nanopath
-uv sync --extra gpuaug --extra simd --no-install-package pillow
+uv sync
 source .venv/bin/activate
 wandb login  # or: export WANDB_MODE=offline before launching noninteractive SLURM jobs
 
@@ -34,7 +34,7 @@ RUN_DIR=$PWD/data/main/my-run
 # or directly on a GPU machine: python train.py configs/main.yaml output_dir=$RUN_DIR
 ```
 
-`pyproject.toml` pins PyTorch 2.8.0 and torchvision 0.23.0 against the CUDA 12.9 wheel index. Ordinary `uv sync` installs Pillow without Kornia. For GPU augmentation, run `uv sync --extra gpuaug` to install Kornia 0.8.3. If your GPU/driver needs a different CUDA build, edit the `torch` and `torchvision` lines in `pyproject.toml` before `uv sync`.
+`pyproject.toml` pins PyTorch 2.8.0 and torchvision 0.23.0 against the CUDA 12.9 wheel index. By default `uv sync` installs Pillow-SIMD. For Apple Silicon, other ARM CPUs, or x86 CPUs without AVX2, see [Installation](#installation). If your GPU/driver needs a different CUDA build, edit the `torch` and `torchvision` lines in `pyproject.toml` before `uv sync`.
 
 A successful model training prints periodic train lines, appends metrics to `metrics.jsonl`, and writes the final comparison artifact to `summary.json`. `configs/smoke.yaml` is simply meant to pretrain briefly and then run the fixed downstream probe suite to ensure everything works without errors.
 
@@ -242,52 +242,15 @@ Full main `nanopath` recipe:
 
 The checked-in `#SBATCH` lines are specific to our MedARC cluster. On another SLURM cluster, edit those header lines once to match your queue, or run `python train.py ...` directly on an allocated GPU.
 
-### Performance
-
-Nanopath enables these three independent performance flags in the main and smoke configs:
-
-| Config key | Effect when true |
-|---|---|
-| `compile` | Compiles model backbones, heads, losses, and the GPU augmentations if enabled |
-| `fused_adamw` | Use PyTorch's fused AdamW |
-| `gpu_augment` | Applies stain jitter, color changes, blur, and normalization on the GPU |
-
-All loaders crop, resize, and flip PIL images on the CPU. The CPU tail receives float32 crops. The GPU augmentations pipeline requires `uv sync --extra gpuaug`. With `compile: false`, GPU augmentations run eagerly.
-
-Training throughput from 15-minute trials after warmup, each using one H100 at batch size 128:
-
-| Augmentation | Compile + fused AdamW | Tiles/second |
-|---|---|---:|
-| Original CPU | Off | ~300 |
-| Pillow-SIMD | On | ~350 |
-| Pillow + GPU augmentations | Off | ~420 |
-| Pillow + GPU augmentations | On | ~660 |
-| Pillow-SIMD + GPU augmentations | On | ~690 |
-
-The main and smoke configs use the tested fast recipe:
-
-```yaml
-train:
-  compile: true
-  fused_adamw: true
-  gpu_augment: true
-  num_workers: 8
-```
-
-Compilation adds startup time on the first run. Later runs can reuse cached compiled code. Compiler cache defaults to beside `project.wandb_dir` with `TORCHINDUCTOR_CACHE_DIR` and `TRITON_CACHE_DIR` values overriding these paths.
-
-#### Installation
+## Installation
 
 Pillow-SIMD requires an x86 CPU with AVX2 and libjpeg, zlib, and libtiff development headers and libraries.
 
+On Apple Silicon, other ARM CPUs, or x86 CPUs without AVX2, exclude Pillow-SIMD with the following install command:
+
 ```bash
-uv sync --extra gpuaug --extra simd --no-install-package pillow
-./submit/train_1gpu.sbatch configs/main.yaml
+uv sync --no-group simd --group pillow
 ```
-
-Omit `--extra gpuaug` if you only want SIMD. Keep `--no-install-package pillow` whenever you select `simd`: both distributions provide `PIL`. The build uses `-mavx2` and `-O3 -DNDEBUG` from `pyproject.toml`; uv tracks these settings in its build cache. Cluster installations may need site-specific header and library paths.
-
-Run `uv sync --extra gpuaug` to use ordinary Pillow with the default GPU augmentation config. For CPU augmentation, set `train.gpu_augment: false` and run `uv sync`. The selected Pillow backend applies to training and probes. Startup logs and W&B config record its version and import path.
 
 ## Outputs
 

--- a/configs/main.yaml
+++ b/configs/main.yaml
@@ -27,10 +27,10 @@ train:
   seed: 7777
   bf16: true
   activation_checkpointing: false
-  compile: true # compile model, losses, and the optional GPU augmentations
-  fused_adamw: true # faster native AdamW fusion
+  compile: true
+  fused_adamw: true
   batch_size: 128
-  gpu_augment: true # use fast GPU augmentation with Kornia. Pair with compile: true for better performance.
+  gpu_augment: true
   num_workers: 8
   prefetch_factor: 2
   persistent_workers: true

--- a/configs/main.yaml
+++ b/configs/main.yaml
@@ -27,11 +27,11 @@ train:
   seed: 7777
   bf16: true
   activation_checkpointing: false
-  compile: false # compile model, losses, and the optional GPU augmentation tail
-  fused_adamw: false # native AdamW fusion; independent of compilation
+  compile: true # compile model, losses, and the optional GPU augmentation tail
+  fused_adamw: true # native AdamW fusion; independent of compilation
   batch_size: 128
-  gpu_augment: false # requires uv sync --extra gpuaug; PIL geometry stays on CPU
-  num_workers: 16
+  gpu_augment: true # requires uv sync --extra gpuaug; PIL geometry stays on CPU
+  num_workers: 8
   prefetch_factor: 2
   persistent_workers: true
   max_train_samples: 1000000 # tile presentations; global/local crops still count as one sample

--- a/configs/main.yaml
+++ b/configs/main.yaml
@@ -27,10 +27,10 @@ train:
   seed: 7777
   bf16: true
   activation_checkpointing: false
-  compile: false
-  fused_adamw: false
+  compile: false # compile model, losses, and the optional GPU augmentation tail
+  fused_adamw: false # native AdamW fusion; independent of compilation
   batch_size: 128
-  gpu_augment: false # experimental Kornia tail; uint8 geometry remains on CPU
+  gpu_augment: false # requires uv sync --extra gpu; PIL geometry stays on CPU
   num_workers: 16
   prefetch_factor: 2
   persistent_workers: true

--- a/configs/main.yaml
+++ b/configs/main.yaml
@@ -30,7 +30,7 @@ train:
   compile: false # compile model, losses, and the optional GPU augmentation tail
   fused_adamw: false # native AdamW fusion; independent of compilation
   batch_size: 128
-  gpu_augment: false # requires uv sync --extra gpu; PIL geometry stays on CPU
+  gpu_augment: false # requires uv sync --extra gpuaug; PIL geometry stays on CPU
   num_workers: 16
   prefetch_factor: 2
   persistent_workers: true

--- a/configs/main.yaml
+++ b/configs/main.yaml
@@ -30,6 +30,7 @@ train:
   compile: false
   fused_adamw: false
   batch_size: 128
+  gpu_augment: false # experimental Kornia tail; uint8 geometry remains on CPU
   num_workers: 16
   prefetch_factor: 2
   persistent_workers: true

--- a/configs/main.yaml
+++ b/configs/main.yaml
@@ -27,6 +27,8 @@ train:
   seed: 7777
   bf16: true
   activation_checkpointing: false
+  compile: false
+  fused_adamw: false
   batch_size: 128
   num_workers: 16
   prefetch_factor: 2

--- a/configs/main.yaml
+++ b/configs/main.yaml
@@ -27,10 +27,10 @@ train:
   seed: 7777
   bf16: true
   activation_checkpointing: false
-  compile: true # compile model, losses, and the optional GPU augmentation tail
-  fused_adamw: true # native AdamW fusion; independent of compilation
+  compile: true # compile model, losses, and the optional GPU augmentations
+  fused_adamw: true # faster native AdamW fusion
   batch_size: 128
-  gpu_augment: true # requires uv sync --extra gpuaug; PIL geometry stays on CPU
+  gpu_augment: true # use fast GPU augmentation with Kornia. Pair with compile: true for better performance.
   num_workers: 8
   prefetch_factor: 2
   persistent_workers: true

--- a/configs/smoke.yaml
+++ b/configs/smoke.yaml
@@ -27,11 +27,11 @@ train:
   seed: 1337
   bf16: true
   activation_checkpointing: false
-  compile: false # compile model, losses, and the optional GPU augmentation tail
-  fused_adamw: false # native AdamW fusion; independent of compilation
+  compile: true # compile model, losses, and the optional GPU augmentation tail
+  fused_adamw: true # native AdamW fusion; independent of compilation
   batch_size: 128
-  gpu_augment: false # requires uv sync --extra gpuaug; PIL geometry stays on CPU
-  num_workers: 16
+  gpu_augment: true # requires uv sync --extra gpuaug; PIL geometry stays on CPU
+  num_workers: 8
   prefetch_factor: 2
   persistent_workers: true
   max_train_samples: 1000000 # full-run sample cap; smoke normally reaches max_train_flops first

--- a/configs/smoke.yaml
+++ b/configs/smoke.yaml
@@ -27,6 +27,8 @@ train:
   seed: 1337
   bf16: true
   activation_checkpointing: false
+  compile: false
+  fused_adamw: false
   batch_size: 128
   num_workers: 16
   prefetch_factor: 2

--- a/configs/smoke.yaml
+++ b/configs/smoke.yaml
@@ -30,7 +30,7 @@ train:
   compile: false # compile model, losses, and the optional GPU augmentation tail
   fused_adamw: false # native AdamW fusion; independent of compilation
   batch_size: 128
-  gpu_augment: false # requires uv sync --extra gpu; PIL geometry stays on CPU
+  gpu_augment: false # requires uv sync --extra gpuaug; PIL geometry stays on CPU
   num_workers: 16
   prefetch_factor: 2
   persistent_workers: true

--- a/configs/smoke.yaml
+++ b/configs/smoke.yaml
@@ -27,10 +27,10 @@ train:
   seed: 1337
   bf16: true
   activation_checkpointing: false
-  compile: true # compile model, losses, and the optional GPU augmentation tail
-  fused_adamw: true # native AdamW fusion; independent of compilation
+  compile: true # compile model, losses, and the optional GPU augmentations
+  fused_adamw: true # faster native AdamW fusion
   batch_size: 128
-  gpu_augment: true # requires uv sync --extra gpuaug; PIL geometry stays on CPU
+  gpu_augment: true # use fast GPU augmentation with Kornia. Pair with compile: true for better performance.
   num_workers: 8
   prefetch_factor: 2
   persistent_workers: true

--- a/configs/smoke.yaml
+++ b/configs/smoke.yaml
@@ -27,10 +27,10 @@ train:
   seed: 1337
   bf16: true
   activation_checkpointing: false
-  compile: false
-  fused_adamw: false
+  compile: false # compile model, losses, and the optional GPU augmentation tail
+  fused_adamw: false # native AdamW fusion; independent of compilation
   batch_size: 128
-  gpu_augment: false # experimental Kornia tail; uint8 geometry remains on CPU
+  gpu_augment: false # requires uv sync --extra gpu; PIL geometry stays on CPU
   num_workers: 16
   prefetch_factor: 2
   persistent_workers: true

--- a/configs/smoke.yaml
+++ b/configs/smoke.yaml
@@ -30,6 +30,7 @@ train:
   compile: false
   fused_adamw: false
   batch_size: 128
+  gpu_augment: false # experimental Kornia tail; uint8 geometry remains on CPU
   num_workers: 16
   prefetch_factor: 2
   persistent_workers: true

--- a/configs/smoke.yaml
+++ b/configs/smoke.yaml
@@ -27,10 +27,10 @@ train:
   seed: 1337
   bf16: true
   activation_checkpointing: false
-  compile: true # compile model, losses, and the optional GPU augmentations
-  fused_adamw: true # faster native AdamW fusion
+  compile: true
+  fused_adamw: true
   batch_size: 128
-  gpu_augment: true # use fast GPU augmentation with Kornia. Pair with compile: true for better performance.
+  gpu_augment: true
   num_workers: 8
   prefetch_factor: 2
   persistent_workers: true

--- a/dataloader.py
+++ b/dataloader.py
@@ -199,6 +199,7 @@ class TCGATileDataset(Dataset):
                 tile = img.convert("RGB")
             if self.tissue_thresh <= 0:
                 break
+            # temporary until we precalculate the tile tissue percentage
             rgb = v2.functional.to_image(tile).float() / 255
             sat = (rgb.amax(0) - rgb.amin(0)) / (rgb.amax(0) + 1e-6)
             if float((sat > 0.07).float().mean()) >= self.tissue_thresh:

--- a/dataloader.py
+++ b/dataloader.py
@@ -13,8 +13,7 @@
 # stays cleanly out-of-distribution from optimization.
 #
 # Each view uses PIL crop/resize/flips, then optional HED jitter, color jitter,
-# grayscale/blur, and normalization. The CPU tail receives float32 crops; the
-# optional Kornia GPU tail receives uint8 crops and compiles only when requested.
+# grayscale/blur, and normalization.
 #
 # This file is the *pretraining* input pipeline only. The downstream probes
 # (probe.py) do not import anything from here.

--- a/dataloader.py
+++ b/dataloader.py
@@ -3,8 +3,8 @@
 # directly (NOT `datasets.load_dataset`, which copies into ~/.cache) so the
 # ~120 GB of shards are mmap'd in place with zero duplication. Random access
 # is resolved by per-shard ParquetFile.read_row_group; prepare.py packs each
-# shard with PARQUET_ROW_GROUP_SIZE=64 rows/group so reading one row group is
-# ~2 MB and __getitem__ is ~2-3 ms incl. JPEG decode.
+# shard with PARQUET_ROW_GROUP_SIZE=64 rows/group. Smaller row groups reduce
+# unused JPEG reads but increase Parquet metadata and index startup cost.
 #
 # Patients (not tiles) are hashed by TCGA barcode and the bottom `val_fraction`
 # of the hash space is held out from training; train.py instantiates the dataset
@@ -12,8 +12,9 @@
 # lightweight DINO/iBOT/KDE validation pass), so the held-out patient slice
 # stays cleanly out-of-distribution from optimization.
 #
-# Augmentation per view: RandomResizedCrop -> optional HEDJitter -> horizontal/
-# vertical flips -> ColorJitter -> occasional grayscale/blur -> Normalize.
+# Each view uses PIL crop/resize/flips, then optional HED jitter, color jitter,
+# grayscale/blur, and normalization. The CPU tail receives float32 crops; the
+# optional Kornia GPU tail receives uint8 crops and compiles only when requested.
 #
 # This file is the *pretraining* input pipeline only. The downstream probes
 # (probe.py) do not import anything from here.
@@ -75,14 +76,46 @@ class HEDJitter(nn.Module):
 
     # Perturb HED channels, then convert back to RGB while the crop is still in [0, 1].
     def forward(self, x):
-        rgb = x.permute(1, 2, 0).clamp_min(1e-6)
+        rgb = x.movedim(-3, -1).clamp_min(1e-6)
         hed = (torch.log(rgb) / LOG_1E6) @ self.hed_from_rgb.to(dtype=x.dtype)
         hed = hed.clamp_min(0.0)
-        shift = torch.randn((1, 1, 3), dtype=x.dtype) * self.sigma
-        scale = 1.0 + torch.randn((1, 1, 3), dtype=x.dtype) * self.sigma
+        shape = (*x.shape[:-3], 1, 1, 3)
+        shift = torch.randn(shape, dtype=x.dtype, device=x.device) * self.sigma
+        scale = 1.0 + torch.randn(shape, dtype=x.dtype, device=x.device) * self.sigma
         hed = hed * scale + shift
         log_rgb = -(hed * (-LOG_1E6)) @ self.rgb_from_hed.to(dtype=x.dtype)
-        return torch.exp(log_rgb).clamp_(0.0, 1.0).permute(2, 0, 1)
+        return torch.exp(log_rgb).clamp_(0.0, 1.0).movedim(-1, -3)
+
+
+# Batched GPU tail; CPU workers send uint8 crops to reduce transfer and worker work.
+class GPUAugment(nn.Module):
+    def __init__(self, data):
+        super().__init__()
+        self.hed = HEDJitter(data["hed_jitter"]) if data["hed_jitter"] > 0 else nn.Identity()
+        for name, value in [("mean", data["mean"]), ("std", data["std"]),
+                            ("jitter", [data["color_jitter"], data["color_jitter"], data["color_jitter_saturation"]])]:
+            self.register_buffer(name, torch.tensor(value).view(1, 3, 1, 1))
+
+    @torch.no_grad()
+    def forward(self, views):
+        import kornia as K
+        shape = views.shape
+        x = self.hed(views.flatten(0, 1).float() / 255)
+        n = x.shape[0]
+        factors = 1 + (torch.rand(n, 3, 1, 1, device=x.device) * 2 - 1) * self.jitter
+        order = torch.rand(n, 3, device=x.device).argsort(1)
+        # Kornia's high-level jitter shares order; functions preserve per-view orders.
+        for position in range(3):
+            brightness = K.enhance.adjust_brightness_accumulative(x, factors[:, 0, 0, 0])
+            contrast = K.enhance.adjust_contrast_with_mean_subtraction(x, factors[:, 1, 0, 0])
+            saturation = K.enhance.adjust_saturation_with_gray_subtraction(x, factors[:, 2, 0, 0])
+            op = order[:, position, None, None, None]
+            x = torch.where(op == 0, brightness, torch.where(op == 1, contrast, saturation))
+        x = torch.where(torch.rand(n, 1, 1, 1, device=x.device) < 0.1, K.color.rgb_to_grayscale(x), x)
+        sigma = (0.1 + torch.rand(n, 1, device=x.device) * 1.7).expand(-1, 2)
+        blurred = K.filters.gaussian_blur2d(x, (9, 9), sigma, border_type="reflect", separable=True)
+        x = torch.where(torch.rand(n, 1, 1, 1, device=x.device) < 0.35, blurred, x)
+        return ((x - self.mean) / self.std).reshape(shape)
 
 
 # Map-style TCGA tile dataset that emits global/local multi-view stacks for train.py.
@@ -125,16 +158,19 @@ class TCGATileDataset(Dataset):
         mean, std = data["mean"], data["std"]
         self.global_views = int(train["global_views"])
         self.local_views = int(train["local_views"])
-        self.to_tensor = v2.Compose([v2.ToImage(), v2.ToDtype(torch.float32, scale=True)])
         # Global and local views differ only in crop scale/size; the stochastic tail is shared.
         augment = [
-            *([HEDJitter(data["hed_jitter"])] if data["hed_jitter"] > 0 else []),
-            v2.RandomHorizontalFlip(), v2.RandomVerticalFlip(),
-            v2.ColorJitter(data["color_jitter"], data["color_jitter"], data["color_jitter_saturation"], 0.0),
-            v2.RandomGrayscale(p=0.1),
-            v2.RandomApply([v2.GaussianBlur(9, sigma=(0.1, 1.8))], p=0.35),
-            v2.Normalize(mean=mean, std=std),
+            v2.RandomHorizontalFlip(), v2.RandomVerticalFlip(), v2.ToImage(),
         ]
+        if not train["gpu_augment"]:
+            augment += [
+                v2.ToDtype(torch.float32, scale=True),
+                *([HEDJitter(data["hed_jitter"])] if data["hed_jitter"] > 0 else []),
+                v2.ColorJitter(data["color_jitter"], data["color_jitter"], data["color_jitter_saturation"], 0.0),
+                v2.RandomGrayscale(p=0.1),
+                v2.RandomApply([v2.GaussianBlur(9, sigma=(0.1, 1.8))], p=0.35),
+                v2.Normalize(mean=mean, std=std),
+            ]
         self.global_aug = v2.Compose([v2.RandomResizedCrop(train["global_size"], scale=tuple(data["global_crop_scale"]), antialias=True), *augment])
         self.local_aug = v2.Compose([v2.RandomResizedCrop(train["local_size"], scale=tuple(data["local_crop_scale"]), antialias=True), *augment])
 
@@ -152,8 +188,7 @@ class TCGATileDataset(Dataset):
             if reader is None:
                 reader = pq.ParquetFile(str(self.shards[shard_idx]), memory_map=True)
                 self._readers[shard_idx] = reader
-            # Each shard has uniform-size row groups (PARQUET_ROW_GROUP_SIZE in
-            # prepare.py); reading one group is ~2 MB and ~2-3 ms incl. JPEG decode.
+            # Read the actual group size so repacked shards keep the same sample indices.
             rg_size = reader.metadata.row_group(0).num_rows
             rg_idx = row_idx // rg_size
             row_in_rg = row_idx % rg_size
@@ -161,10 +196,11 @@ class TCGATileDataset(Dataset):
             rel = table["path"][row_in_rg].as_py()
             jpeg_bytes = table["jpeg"][row_in_rg].as_py()
             with Image.open(io.BytesIO(jpeg_bytes)) as img:
-                tile = self.to_tensor(img.convert("RGB"))
+                tile = img.convert("RGB")
             if self.tissue_thresh <= 0:
                 break
-            sat = (tile.amax(0) - tile.amin(0)) / (tile.amax(0) + 1e-6)
+            rgb = v2.functional.to_image(tile).float() / 255
+            sat = (rgb.amax(0) - rgb.amin(0)) / (rgb.amax(0) + 1e-6)
             if float((sat > 0.07).float().mean()) >= self.tissue_thresh:
                 break
             idx = random.randint(0, self.shard_of.shape[0] - 1)

--- a/dataloader.py
+++ b/dataloader.py
@@ -86,7 +86,6 @@ class HEDJitter(nn.Module):
         return torch.exp(log_rgb).clamp_(0.0, 1.0).movedim(-1, -3)
 
 
-# Batched GPU tail; CPU workers send uint8 crops to reduce transfer and worker work.
 class GPUAugment(nn.Module):
     def __init__(self, data):
         super().__init__()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ dependencies = [
   "timm>=1.0.27",
 ]
 
+[project.optional-dependencies]
+gpu = ["kornia==0.8.3"]
+
 [tool.uv]
 package = false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,15 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-gpu = ["kornia==0.8.3"]
+gpuaug = ["kornia==0.8.3"]
+simd = ["pillow-simd==9.5.0.post2"]
 
 [tool.uv]
 package = false
+no-binary-package = ["pillow-simd"]
+
+[tool.uv.extra-build-variables]
+pillow-simd = { CC = "cc -mavx2", CFLAGS = "-O3 -DNDEBUG" }
 
 [tool.uv.sources]
 torch = { index = "pytorch-cu129" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,20 @@ dependencies = [
   "timm>=1.0.27",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 gpuaug = ["kornia==0.8.3"]
 simd = ["pillow-simd==9.5.0.post2"]
+pillow = ["pillow"]
 
 [tool.uv]
 package = false
+default-groups = ["gpuaug", "simd"]
+# Select one PIL provider through groups instead of transitive requirements.
+exclude-dependencies = [
+  { package = { name = "torchvision" }, dependencies = ["pillow"] },
+  { package = { name = "openslide-python" }, dependencies = ["pillow"] },
+]
+conflicts = [[{ group = "simd" }, { group = "pillow" }]]
 no-binary-package = ["pillow-simd"]
 
 [tool.uv.extra-build-variables]

--- a/train.py
+++ b/train.py
@@ -29,7 +29,7 @@ import yaml
 from torch.utils.data import DataLoader
 from torch.utils.flop_counter import FlopCounterMode
 
-from dataloader import TCGATileDataset, TILE_SIZE
+from dataloader import GPUAugment, TCGATileDataset, TILE_SIZE
 from model import DINOHead, ViT, load_pretrained
 from probe import (
     completed_probe_summary,
@@ -370,6 +370,17 @@ def main():
     wandb_meta = {"entity": wandb_run.entity, "project": "nanopath", "id": wandb_run.id, "name": wandb_name, "url": wandb_run.url,
                   "mode": getattr(wandb_run.settings, "mode", ""), "source_artifact": source_id,
                   "source_dir": str(source_snapshot_dir), "git": {"commit": git_commit, "remote": git_remote}}
+    augment = torch.nn.Identity()
+    if train_cfg["gpu_augment"]:
+        augment = GPUAugment(cfg["data"]).to(device)
+        if train_cfg["compile"]:
+            augment.compile()
+            # Compile before timing; preserve the training RNG state through warmup.
+            rng = torch.cuda.get_rng_state(device)
+            for views, size in [(train_cfg["global_views"], train_cfg["global_size"]), (train_cfg["local_views"], train_cfg["local_size"])]:
+                augment(torch.zeros(batch_size, views, 3, size, size, dtype=torch.uint8, device=device))
+            torch.cuda.synchronize(device)
+            torch.cuda.set_rng_state(rng, device)
     train_ds = TCGATileDataset(cfg, is_train=True)
     val_ds = TCGATileDataset(cfg, is_train=False)
     probe_state = prepare_probe_state(cfg, output_dir) if probe_enabled(cfg) else None
@@ -472,7 +483,7 @@ def main():
         for vb_idx, vbatch in enumerate(val_loader):
             if vb_idx >= int(train_cfg["val_batches"]):
                 break
-            vg, vl = vbatch["global_views"].to(device, non_blocking=True), vbatch["local_views"].to(device, non_blocking=True)
+            vg, vl = [augment(vbatch[key].to(device, non_blocking=True)) for key in ("global_views", "local_views")]
             b = vg.shape[0]
             with torch.no_grad(), autocast:
                 gf, lf = vg.transpose(0, 1).flatten(0, 1), vl.transpose(0, 1).flatten(0, 1)
@@ -547,7 +558,7 @@ def main():
             # Data identifiers stay on CPU and feed coverage metrics; image tensors move below.
             for key, batch_key in (("sample", "sample_idx"), ("slide", "slide_id"), ("patient", "patient_id")):
                 pending_ids[key].update(int(x) for x in batch[batch_key].tolist())
-            global_views, local_views = [batch[key].to(device, non_blocking=True) for key in ("global_views", "local_views")]
+            global_views, local_views = [augment(batch[key].to(device, non_blocking=True)) for key in ("global_views", "local_views")]
             visible_now = batch_size * (train_cfg["global_views"] * global_patches + train_cfg["local_views"] * local_patches)
             # LR warmup uses the 1M-tile sample cap; decay/WD/teacher/freeze/KDE stay on the public FLOP budget.
             frac = min(1.0, train_flops / max_train_flops)

--- a/train.py
+++ b/train.py
@@ -158,6 +158,11 @@ def dino_ce(student, teacher):
     return -(teacher * F.log_softmax(student / 0.1, dim=-1)).sum(-1).mean()
 
 
+# Weight masked patches by their image's inverse mask count before summing iBOT CE.
+def ibot_ce(student, teacher, weights):
+    return -(teacher * F.log_softmax(student / 0.1, dim=-1)).sum(-1).mul(weights).sum()
+
+
 # KDE uniformity loss on L2-normalised CLS tokens.
 def kde_loss(x, concentration):
     x = F.normalize(x, p=2, dim=-1)
@@ -245,7 +250,7 @@ def main():
             p.requires_grad = False
     backbone_activated_params = sum(p.numel() for p in student_backbone.parameters() if p.requires_grad)
     # AdamW param groups carry per-parameter LR/WD multipliers (LWD + patch_embed + biases-no-WD).
-    opt = torch.optim.AdamW(build_param_groups(student_backbone, student_dino_head, student_ibot_head, dino_cfg["layerwise_decay"], dino_cfg["patch_embed_lr_mult"]), lr=1.0, betas=(0.9, dino_cfg["adam_beta2"]))
+    opt = torch.optim.AdamW(build_param_groups(student_backbone, student_dino_head, student_ibot_head, dino_cfg["layerwise_decay"], dino_cfg["patch_embed_lr_mult"]), lr=1.0, betas=(0.9, dino_cfg["adam_beta2"]), fused=train_cfg["fused_adamw"])
     step = 0
     batch_size = int(train_cfg["batch_size"])
     max_train_samples = int(train_cfg["max_train_samples"])
@@ -254,6 +259,14 @@ def main():
     train_flops = 0
     output_dir = Path(cfg["project"]["output_dir"])
     wandb_dir = Path(cfg["project"]["wandb_dir"])
+    for key, name in [("TORCHINDUCTOR_CACHE_DIR", "inductor"), ("TRITON_CACHE_DIR", "triton")]:
+        os.environ.setdefault(key, str(wandb_dir.parent / name))
+    # Compile calls in place so checkpoint keys and parameter ownership stay unchanged.
+    for module in (student_backbone, teacher_backbone, student_dino_head, student_ibot_head, teacher_dino_head, teacher_ibot_head):
+        module.compile(dynamic=isinstance(module, DINOHead), disable=not train_cfg["compile"])
+    sinkhorn_fn = torch.compile(sinkhorn, dynamic=True, disable=not train_cfg["compile"])
+    dino_ce_fn = torch.compile(dino_ce, dynamic=True, disable=not train_cfg["compile"])
+    ibot_ce_fn = torch.compile(ibot_ce, dynamic=True, disable=not train_cfg["compile"])
     wandb_name = cfg["project"]["name"]
     if labless_autosubmit_file:
         wandb_name = json.loads(Path(labless_autosubmit_file).read_text()).get("run_name") or wandb_name
@@ -278,6 +291,11 @@ def main():
         student_ibot_head.load_state_dict(checkpoint["ibot_head"])
         teacher_dino_head.load_state_dict(checkpoint["dino_head_ema"])
         teacher_ibot_head.load_state_dict(checkpoint["ibot_head_ema"])
+        # The requested backend owns step placement, even when the saved backend differs.
+        for group in checkpoint["opt"]["param_groups"]:
+            group.update(fused=train_cfg["fused_adamw"], foreach=None)
+        for state in checkpoint["opt"]["state"].values():
+            state["step"] = state["step"].to(device if train_cfg["fused_adamw"] else "cpu")
         opt.load_state_dict(checkpoint["opt"])
         step = int(checkpoint["step"])
         examples_seen = int(checkpoint["examples_seen"])
@@ -420,19 +438,23 @@ def main():
     # Compute (dino_loss, ibot_loss, kde) for one batch of (gf, lf) crops with the given masks +
     # schedule values. Used by both the train step and evaluate() (no_grad).
     def compute_losses(gf, lf, b, masks, mask_idx, mask_w, t_temp, k_scale, ckpt=False):
+        # Tensor schedule values do not specialize Sinkhorn to each temperature.
+        t_temp = torch.tensor(t_temp, device=gf.device)
         with torch.no_grad():
             t = teacher_backbone(gf)
             t_cls = teacher_dino_head(t["cls"]).chunk(train_cfg["global_views"])
-            t_prob = sinkhorn(torch.cat((t_cls[1], t_cls[0])), t_temp).view(2, b, -1)
-            t_patch_prob = sinkhorn(teacher_ibot_head(t["patches"].flatten(0, 1)[mask_idx]), t_temp)
+            t_prob = sinkhorn_fn(torch.cat((t_cls[1], t_cls[0])), t_temp).view(2, b, -1)
+            t_patch_prob = sinkhorn_fn(teacher_ibot_head(t["patches"].flatten(0, 1)[mask_idx]), t_temp)
         sg = student_backbone(gf, masks=masks, checkpoint=ckpt)
         sl = student_backbone(lf, checkpoint=ckpt)
         sg_cls, sl_cls = student_dino_head(sg["cls"]), student_dino_head(sl["cls"])
         L = train_cfg["local_views"]
-        local_loss = sum(dino_ce(x, y) for x in sl_cls.chunk(L) for y in t_prob) / (2 * L + 2)
-        global_loss = dino_ce(sg_cls, t_prob.flatten(0, 1)) * 2 / (2 * L + 2)
+        # CE is linear in targets; keep the original reduction order for eager recipes.
+        local_loss = (dino_ce_fn(sl_cls.view(L, b, -1), t_prob.sum(0)) * L if train_cfg["compile"]
+                      else sum(dino_ce_fn(x, y) for x in sl_cls.chunk(L) for y in t_prob)) / (2 * L + 2)
+        global_loss = dino_ce_fn(sg_cls, t_prob.flatten(0, 1)) * 2 / (2 * L + 2)
         s_patch = student_ibot_head(sg["patches"].flatten(0, 1)[mask_idx])
-        ibot_loss = -(t_patch_prob * F.log_softmax(s_patch / 0.1, dim=-1)).sum(-1).mul(mask_w).sum() / max(1, b * 2)
+        ibot_loss = ibot_ce_fn(s_patch, t_patch_prob, mask_w) / max(1, b * 2)
         kde = dino_cfg["kde_loss_weight"] * k_scale * sum(kde_loss(x, dino_cfg["kde_concentration"]) for x in sg["cls"].chunk(train_cfg["global_views"]))
         return local_loss + global_loss, ibot_loss, kde
 
@@ -546,7 +568,8 @@ def main():
             # Wrap forward + backward + opt.step in FlopCounterMode on the first step only;
             # subsequent steps reuse measured_flops_per_step (fixed shapes => fixed cost).
             flop_ctx = FlopCounterMode(display=False) if measured_flops_per_step is None else contextlib.nullcontext()
-            with flop_ctx:
+            # Compiled kernels are opaque to the counter; measure the first step eagerly.
+            with flop_ctx, torch.compiler.set_stance("force_eager" if measured_flops_per_step is None else "default"):
                 with autocast:
                     # Crop-major flatten: collate shape is (B, V, 3, H, W) but DINO wants per-crop chunks
                     # so [crop0_img0, crop0_img1, ..., crop1_img0, ...] for clean teacher/student alignment.
@@ -573,7 +596,6 @@ def main():
                 update_ema(student_backbone, teacher_backbone, m)
                 update_ema(student_dino_head, teacher_dino_head, m)
                 update_ema(student_ibot_head, teacher_ibot_head, m)
-            step_seconds = time.monotonic() - batch_started_at
             examples_seen += batch_size
             visible_patch_presentations += visible_now
             train_flops += step_train_flops
@@ -584,6 +606,7 @@ def main():
                     "kde": float(kde.detach()),
                     "total": float(total_loss.detach()),
                 }
+                step_seconds = time.monotonic() - batch_started_at  # Loss transfers wait for GPU completion.
                 unique_counts = flush_unique_counts()
                 now = time.time()
                 elapsed = max(1e-6, now - last_time)

--- a/train.py
+++ b/train.py
@@ -21,6 +21,7 @@ from copy import deepcopy
 from pathlib import Path
 
 import numpy as np
+import PIL
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -316,6 +317,7 @@ def main():
         wandb_init["id"] = wandb_meta["id"]
         wandb_init["resume"] = "must"
     wandb_run = wandb.init(**wandb_init)
+    wandb_run.config.update({"pillow": {"version": PIL.__version__, "path": PIL.__file__}}, allow_val_change=True)
     for key in ("probe/target_flops", "probe/wall_seconds"):
         wandb_run.define_metric(key, hidden=True, overwrite=True)
     print(
@@ -326,7 +328,7 @@ def main():
         f"probe_count: {cfg['probe']['count']}  warmup_fraction: {dino_cfg['warmup_fraction']}  "
         f"lr: {dino_cfg['lr']}  adam_beta2: {dino_cfg['adam_beta2']}  kde_loss_weight: {dino_cfg['kde_loss_weight']}  "
         f"kde_concentration: {dino_cfg['kde_concentration']}  drop_path: {dino_cfg['drop_path_rate']}  "
-        f"layerwise_decay: {dino_cfg['layerwise_decay']}",
+        f"layerwise_decay: {dino_cfg['layerwise_decay']}  pillow: {PIL.__version__} ({PIL.__file__})",
         flush=True,
     )
     git_commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo_dir, text=True).strip()

--- a/uv.lock
+++ b/uv.lock
@@ -370,18 +370,22 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-gpu = [
+gpuaug = [
     { name = "kornia" },
+]
+simd = [
+    { name = "pillow-simd" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "h5py", specifier = ">=3.16.0" },
     { name = "huggingface-hub", specifier = ">=0.30.0" },
-    { name = "kornia", marker = "extra == 'gpu'", specifier = "==0.8.3" },
+    { name = "kornia", marker = "extra == 'gpuaug'", specifier = "==0.8.3" },
     { name = "numpy", specifier = ">=2.2.0" },
     { name = "openslide-bin", specifier = ">=4.0.0" },
     { name = "openslide-python", specifier = ">=1.4.0" },
+    { name = "pillow-simd", marker = "extra == 'simd'", specifier = "==9.5.0.post2" },
     { name = "pyarrow", specifier = ">=19.0.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "safetensors", specifier = ">=0.6.0" },
@@ -392,7 +396,7 @@ requires-dist = [
     { name = "torchvision", specifier = "==0.23.0+cu129", index = "https://download.pytorch.org/whl/cu129" },
     { name = "wandb", specifier = ">=0.20.0" },
 ]
-provides-extras = ["gpu"]
+provides-extras = ["gpuaug", "simd"]
 
 [[package]]
 name = "networkx"
@@ -478,7 +482,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -489,7 +493,7 @@ name = "nvidia-cufft-cu12"
 version = "11.4.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/95/f4/61e6996dd20481ee834f57a8e9dca28b1869366a135e0d42e2aa8493bdd4/nvidia_cufft_cu12-11.4.1.4-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c67884f2a7d276b4b80eb56a79322a95df592ae5e765cf1243693365ccab4e28", size = 200877592, upload-time = "2025-06-05T20:05:45.862Z" },
@@ -516,9 +520,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.5.82"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/40/79b0c64d44d6c166c0964ec1d803d067f4a145cca23e23925fd351d0e642/nvidia_cusolver_cu12-11.7.5.82-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:15da72d1340d29b5b3cf3fd100e3cd53421dde36002eda6ed93811af63c40d88", size = 338117415, upload-time = "2025-06-05T20:07:16.809Z" },
@@ -529,7 +533,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.10.65"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/46/b0fd4b04f86577921feb97d8e2cf028afe04f614d17fb5013de9282c9216/nvidia_cusparse_cu12-12.5.10.65-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:73060ce019ac064a057267c585bf1fd5a353734151f87472ff02b2c5c9984e78", size = 366465088, upload-time = "2025-06-05T20:08:20.413Z" },
@@ -662,6 +666,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
     { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
 ]
+
+[[package]]
+name = "pillow-simd"
+version = "9.5.0.post2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/d9/5cf8d7c9ecaf389fe62570a5287036611f1328796ed6e59abbc2dc09f4a6/Pillow-SIMD-9.5.0.post2.tar.gz", hash = "sha256:39dfb027bdaa3e35597df9a1c42ea97091f32bc83f25ab9cab0845b3c4bad331", size = 904623, upload-time = "2024-09-23T18:27:59.716Z" }
 
 [[package]]
 name = "platformdirs"
@@ -1045,7 +1055,7 @@ name = "triton"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "setuptools", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "setuptools" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/66/b1eb52839f563623d185f0927eb3530ee4d5ffe9d377cdaf5346b306689e/triton-3.4.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:31c1d84a5c0ec2c0f8e8a072d7fd150cab84a9c239eaddc6706c081bfae4eb04", size = 155560068, upload-time = "2025-07-30T19:58:37.081Z" },

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,16 @@ resolution-markers = [
     "sys_platform == 'emscripten'",
     "sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
+conflicts = [[
+    { package = "nanopath", group = "pillow" },
+    { package = "nanopath", group = "simd" },
+]]
+
+[manifest]
+excludes = [
+    { package = { name = "openslide-python" }, dependencies = ["pillow"] },
+    { package = { name = "torchvision" }, dependencies = ["pillow"] },
+]
 
 [[package]]
 name = "annotated-doc"
@@ -77,7 +87,7 @@ name = "click"
 version = "8.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
 wheels = [
@@ -229,7 +239,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' or (extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd')" },
     { name = "httpx" },
     { name = "packaging" },
     { name = "pyyaml" },
@@ -369,9 +379,12 @@ dependencies = [
     { name = "wandb" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 gpuaug = [
     { name = "kornia" },
+]
+pillow = [
+    { name = "pillow" },
 ]
 simd = [
     { name = "pillow-simd" },
@@ -381,11 +394,9 @@ simd = [
 requires-dist = [
     { name = "h5py", specifier = ">=3.16.0" },
     { name = "huggingface-hub", specifier = ">=0.30.0" },
-    { name = "kornia", marker = "extra == 'gpuaug'", specifier = "==0.8.3" },
     { name = "numpy", specifier = ">=2.2.0" },
     { name = "openslide-bin", specifier = ">=4.0.0" },
     { name = "openslide-python", specifier = ">=1.4.0" },
-    { name = "pillow-simd", marker = "extra == 'simd'", specifier = "==9.5.0.post2" },
     { name = "pyarrow", specifier = ">=19.0.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "safetensors", specifier = ">=0.6.0" },
@@ -396,7 +407,11 @@ requires-dist = [
     { name = "torchvision", specifier = "==0.23.0+cu129", index = "https://download.pytorch.org/whl/cu129" },
     { name = "wandb", specifier = ">=0.20.0" },
 ]
-provides-extras = ["gpuaug", "simd"]
+
+[package.metadata.requires-dev]
+gpuaug = [{ name = "kornia", specifier = "==0.8.3" }]
+pillow = [{ name = "pillow" }]
+simd = [{ name = "pillow-simd", specifier = "==9.5.0.post2" }]
 
 [[package]]
 name = "networkx"
@@ -450,7 +465,9 @@ name = "nvidia-cublas-cu12"
 version = "12.9.1.4"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/6c/90d3f532f608a03a13c1d6c16c266ffa3828e8011b1549d3b61db2ad59f5/nvidia_cublas_cu12-12.9.1.4-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:7a950dae01add3b415a5a5cdc4ec818fb5858263e9cca59004bb99fdbbd3a5d6", size = 575006342, upload-time = "2025-06-05T20:04:16.902Z" },
     { url = "https://files.pythonhosted.org/packages/77/3c/aa88abe01f3be3d1f8f787d1d33dc83e76fec05945f9a28fbb41cfb99cd5/nvidia_cublas_cu12-12.9.1.4-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:453611eb21a7c1f2c2156ed9f3a45b691deda0440ec550860290dc901af5b4c2", size = 581242350, upload-time = "2025-06-05T20:04:51.979Z" },
+    { url = "https://files.pythonhosted.org/packages/45/a1/a17fade6567c57452cfc8f967a40d1035bb9301db52f27808167fbb2be2f/nvidia_cublas_cu12-12.9.1.4-py3-none-win_amd64.whl", hash = "sha256:1e5fee10662e6e52bd71dec533fbbd4971bb70a5f24f3bc3793e5c2e9dc640bf", size = 553153899, upload-time = "2025-06-05T20:13:35.556Z" },
 ]
 
 [[package]]
@@ -458,7 +475,9 @@ name = "nvidia-cuda-cupti-cu12"
 version = "12.9.79"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/78/351b5c8cdbd9a6b4fb0d6ee73fb176dcdc1b6b6ad47c2ffff5ae8ca4a1f7/nvidia_cuda_cupti_cu12-12.9.79-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:791853b030602c6a11d08b5578edfb957cadea06e9d3b26adbf8d036135a4afe", size = 10077166, upload-time = "2025-06-05T20:01:01.385Z" },
     { url = "https://files.pythonhosted.org/packages/c1/2e/b84e32197e33f39907b455b83395a017e697c07a449a2b15fd07fc1c9981/nvidia_cuda_cupti_cu12-12.9.79-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:096bcf334f13e1984ba36685ad4c1d6347db214de03dbb6eebb237b41d9d934f", size = 10814997, upload-time = "2025-06-05T20:01:10.168Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/b4/298983ab1a83de500f77d0add86d16d63b19d1a82c59f8eaf04f90445703/nvidia_cuda_cupti_cu12-12.9.79-py3-none-win_amd64.whl", hash = "sha256:1848a9380067560d5bee10ed240eecc22991713e672c0515f9c3d9396adf93c8", size = 7730496, upload-time = "2025-06-05T20:11:26.444Z" },
 ]
 
 [[package]]
@@ -467,6 +486,8 @@ version = "12.9.86"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/85/e4af82cc9202023862090bfca4ea827d533329e925c758f0cde964cb54b7/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:210cf05005a447e29214e9ce50851e83fc5f4358df8b453155d5e1918094dcb4", size = 89568129, upload-time = "2025-06-05T20:02:41.973Z" },
+    { url = "https://files.pythonhosted.org/packages/64/eb/c2295044b8f3b3b08860e2f6a912b702fc92568a167259df5dddb78f325e/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:096d4de6bda726415dfaf3198d4f5c522b8e70139c97feef5cd2ca6d4cd9cead", size = 44528905, upload-time = "2025-06-05T20:02:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/52/de/823919be3b9d0ccbf1f784035423c5f18f4267fb0123558d58b813c6ec86/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-win_amd64.whl", hash = "sha256:72972ebdcf504d69462d3bcd67e7b81edd25d0fb85a2c46d3ea3517666636349", size = 76408187, upload-time = "2025-06-05T20:12:27.819Z" },
 ]
 
 [[package]]
@@ -474,7 +495,9 @@ name = "nvidia-cuda-runtime-cu12"
 version = "12.9.79"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/e0/0279bd94539fda525e0c8538db29b72a5a8495b0c12173113471d28bce78/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:83469a846206f2a733db0c42e223589ab62fd2fabac4432d2f8802de4bded0a4", size = 3515012, upload-time = "2025-06-05T20:00:35.519Z" },
     { url = "https://files.pythonhosted.org/packages/bc/46/a92db19b8309581092a3add7e6fceb4c301a3fd233969856a8cbf042cd3c/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:25bba2dfb01d48a9b59ca474a1ac43c6ebf7011f1b0b8cc44f54eb6ac48a96c3", size = 3493179, upload-time = "2025-06-05T20:00:53.735Z" },
+    { url = "https://files.pythonhosted.org/packages/59/df/e7c3a360be4f7b93cee39271b792669baeb3846c58a4df6dfcf187a7ffab/nvidia_cuda_runtime_cu12-12.9.79-py3-none-win_amd64.whl", hash = "sha256:8e018af8fa02363876860388bd10ccb89eb9ab8fb0aa749aaf58430a9f7c4891", size = 3591604, upload-time = "2025-06-05T20:11:17.036Z" },
 ]
 
 [[package]]
@@ -485,7 +508,9 @@ dependencies = [
     { name = "nvidia-cublas-cu12" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/41/e79269ce215c857c935fd86bcfe91a451a584dfc27f1e068f568b9ad1ab7/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c9132cc3f8958447b4910a1720036d9eff5928cc3179b0a51fb6d167c6cc87d8", size = 705026878, upload-time = "2025-06-06T21:52:51.348Z" },
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/90/0bd6e586701b3a890fd38aa71c387dab4883d619d6e5ad912ccbd05bfd67/nvidia_cudnn_cu12-9.10.2.21-py3-none-win_amd64.whl", hash = "sha256:c6288de7d63e6cf62988f0923f96dc339cea362decb1bf5b3141883392a7d65e", size = 692992268, upload-time = "2025-06-06T21:55:18.114Z" },
 ]
 
 [[package]]
@@ -496,7 +521,9 @@ dependencies = [
     { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/2b/76445b0af890da61b501fde30650a1a4bd910607261b209cccb5235d3daa/nvidia_cufft_cu12-11.4.1.4-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1a28c9b12260a1aa7a8fd12f5ebd82d027963d635ba82ff39a1acfa7c4c0fbcf", size = 200822453, upload-time = "2025-06-05T20:05:27.889Z" },
     { url = "https://files.pythonhosted.org/packages/95/f4/61e6996dd20481ee834f57a8e9dca28b1869366a135e0d42e2aa8493bdd4/nvidia_cufft_cu12-11.4.1.4-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c67884f2a7d276b4b80eb56a79322a95df592ae5e765cf1243693365ccab4e28", size = 200877592, upload-time = "2025-06-05T20:05:45.862Z" },
+    { url = "https://files.pythonhosted.org/packages/20/ee/29955203338515b940bd4f60ffdbc073428f25ef9bfbce44c9a066aedc5c/nvidia_cufft_cu12-11.4.1.4-py3-none-win_amd64.whl", hash = "sha256:8e5bfaac795e93f80611f807d42844e8e27e340e0cde270dcb6c65386d795b80", size = 200067309, upload-time = "2025-06-05T20:13:59.762Z" },
 ]
 
 [[package]]
@@ -505,6 +532,7 @@ version = "1.14.1.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ad/28/b960e06d705a440c030edd84e16888ee14c743390bdb2a6368e92ffe8ef8/nvidia_cufile_cu12-1.14.1.1-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9552e2231792e94b1ff17bc99e958cc0e6bbbaa4a9d91fa2dbeed97716628fe6", size = 1210714, upload-time = "2025-06-05T20:06:11.898Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d2/110af3a1f77999d5eebf6ffae5d2305ab839e53c76eec3696640cc25b35d/nvidia_cufile_cu12-1.14.1.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:8dea77590761e02cb6dd955a57cb6414c58aa3cb1b7adbf9919869a11509cf65", size = 1135994, upload-time = "2025-06-05T20:06:03.952Z" },
 ]
 
 [[package]]
@@ -512,7 +540,9 @@ name = "nvidia-curand-cu12"
 version = "10.3.10.19"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/1c/2a45afc614d99558d4a773fa740d8bb5471c8398eeed925fc0fcba020173/nvidia_curand_cu12-10.3.10.19-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:de663377feb1697e1d30ed587b07d5721fdd6d2015c738d7528a6002a6134d37", size = 68292066, upload-time = "2025-05-01T19:39:13.595Z" },
     { url = "https://files.pythonhosted.org/packages/31/44/193a0e171750ca9f8320626e8a1f2381e4077a65e69e2fb9708bd479e34a/nvidia_curand_cu12-10.3.10.19-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:49b274db4780d421bd2ccd362e1415c13887c53c214f0d4b761752b8f9f6aa1e", size = 68295626, upload-time = "2025-05-01T19:39:38.885Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/98/1bd66fd09cbe1a5920cb36ba87029d511db7cca93979e635fd431ad3b6c0/nvidia_curand_cu12-10.3.10.19-py3-none-win_amd64.whl", hash = "sha256:e8129e6ac40dc123bd948e33d3e11b4aa617d87a583fa2f21b3210e90c743cde", size = 68774847, upload-time = "2025-05-01T19:48:52.93Z" },
 ]
 
 [[package]]
@@ -525,7 +555,9 @@ dependencies = [
     { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/99/686ff9bf3a82a531c62b1a5c614476e8dfa24a9d89067aeedf3592ee4538/nvidia_cusolver_cu12-11.7.5.82-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:62efa83e4ace59a4c734d052bb72158e888aa7b770e1a5f601682f16fe5b4fd2", size = 337869834, upload-time = "2025-06-05T20:06:53.125Z" },
     { url = "https://files.pythonhosted.org/packages/33/40/79b0c64d44d6c166c0964ec1d803d067f4a145cca23e23925fd351d0e642/nvidia_cusolver_cu12-11.7.5.82-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:15da72d1340d29b5b3cf3fd100e3cd53421dde36002eda6ed93811af63c40d88", size = 338117415, upload-time = "2025-06-05T20:07:16.809Z" },
+    { url = "https://files.pythonhosted.org/packages/32/5d/feb7f86b809f89b14193beffebe24cf2e4bf7af08372ab8cdd34d19a65a0/nvidia_cusolver_cu12-11.7.5.82-py3-none-win_amd64.whl", hash = "sha256:77666337237716783c6269a658dea310195cddbd80a5b2919b1ba8735cec8efd", size = 326215953, upload-time = "2025-06-05T20:14:41.76Z" },
 ]
 
 [[package]]
@@ -536,7 +568,9 @@ dependencies = [
     { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/6f/8710fbd17cdd1d0fc3fea7d36d5b65ce1933611c31e1861da330206b253a/nvidia_cusparse_cu12-12.5.10.65-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:221c73e7482dd93eda44e65ce567c031c07e2f93f6fa0ecd3ba876a195023e83", size = 366359408, upload-time = "2025-06-05T20:07:42.501Z" },
     { url = "https://files.pythonhosted.org/packages/12/46/b0fd4b04f86577921feb97d8e2cf028afe04f614d17fb5013de9282c9216/nvidia_cusparse_cu12-12.5.10.65-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:73060ce019ac064a057267c585bf1fd5a353734151f87472ff02b2c5c9984e78", size = 366465088, upload-time = "2025-06-05T20:08:20.413Z" },
+    { url = "https://files.pythonhosted.org/packages/73/ef/063500c25670fbd1cbb0cd3eb7c8a061585b53adb4dd8bf3492bb49b0df3/nvidia_cusparse_cu12-12.5.10.65-py3-none-win_amd64.whl", hash = "sha256:9e487468a22a1eaf1fbd1d2035936a905feb79c4ce5c2f67626764ee4f90227c", size = 362504719, upload-time = "2025-06-05T20:15:17.947Z" },
 ]
 
 [[package]]
@@ -544,7 +578,9 @@ name = "nvidia-cusparselt-cu12"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/b9/598f6ff36faaece4b3c50d26f50e38661499ff34346f00e057760b35cc9d/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8878dce784d0fac90131b6817b607e803c36e629ba34dc5b433471382196b6a5", size = 283835557, upload-time = "2025-02-26T00:16:54.265Z" },
     { url = "https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623", size = 287193691, upload-time = "2025-02-26T00:15:44.104Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/d8/a6b0d0d0c2435e9310f3e2bb0d9c9dd4c33daef86aa5f30b3681defd37ea/nvidia_cusparselt_cu12-0.7.1-py3-none-win_amd64.whl", hash = "sha256:f67fbb5831940ec829c9117b7f33807db9f9678dc2a617fbe781cac17b4e1075", size = 271020911, upload-time = "2025-02-26T00:14:47.204Z" },
 ]
 
 [[package]]
@@ -552,6 +588,7 @@ name = "nvidia-nccl-cu12"
 version = "2.27.3"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/7b/8354b784cf73b0ba51e566b4baba3ddd44fe8288a3d39ef1e06cd5417226/nvidia_nccl_cu12-2.27.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9ddf1a245abc36c550870f26d537a9b6087fb2e2e3d6e0ef03374c6fd19d984f", size = 322397768, upload-time = "2025-06-03T21:57:30.234Z" },
     { url = "https://files.pythonhosted.org/packages/5c/5b/4e4fff7bad39adf89f735f2bc87248c81db71205b62bcc0d5ca5b606b3c3/nvidia_nccl_cu12-2.27.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adf27ccf4238253e0b826bce3ff5fa532d65fc42322c8bfdfaf28024c0fbe039", size = 322364134, upload-time = "2025-06-03T21:58:04.013Z" },
 ]
 
@@ -561,6 +598,8 @@ version = "12.9.86"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/0c/c75bbfb967457a0b7670b8ad267bfc4fffdf341c074e0a80db06c24ccfd4/nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:e3f1171dbdc83c5932a45f0f4c99180a70de9bd2718c1ab77d14104f6d7147f9", size = 39748338, upload-time = "2025-06-05T20:10:25.613Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bc/2dcba8e70cf3115b400fef54f213bcd6715a3195eba000f8330f11e40c45/nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:994a05ef08ef4b0b299829cde613a424382aff7efb08a7172c1fa616cc3af2ca", size = 39514880, upload-time = "2025-06-05T20:10:04.89Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/7e/2eecb277d8a98184d881fb98a738363fd4f14577a4d2d7f8264266e82623/nvidia_nvjitlink_cu12-12.9.86-py3-none-win_amd64.whl", hash = "sha256:cc6fcec260ca843c10e34c936921a1c426b351753587fdd638e8cff7b16bb9db", size = 35584936, upload-time = "2025-06-05T20:16:08.525Z" },
 ]
 
 [[package]]
@@ -569,6 +608,8 @@ version = "12.9.79"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/86/ed/bb230dce7741f2778ba2ae3e8778fdb8bc58eee9fd95f07bf7b2d18e8081/nvidia_nvtx_cu12-12.9.79-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fec150986817f2b4e7eed72ed059f2dcb9ba3856b9a96134e448eac946a6952f", size = 85504, upload-time = "2025-06-05T20:03:10.21Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/e4/82155e4aaedb41621087ba219c95e99c5e417f37a7649b4fb6ec32dcb14d/nvidia_nvtx_cu12-12.9.79-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d1f258e752294acdb4f61c3d31fee87bd0f60e459f1e2f624376369b524cd15d", size = 86120, upload-time = "2025-06-05T20:02:51.838Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/cc/efd28e4b3f4019f7ef176f4baa5c1ef7dcd3ac8c9e6d2b15bcbf3f1297d3/nvidia_nvtx_cu12-12.9.79-py3-none-win_amd64.whl", hash = "sha256:1f504e573b3a955e55aae6c747e2ae561b63fdcafcd591e43d18dae9875504f8", size = 77774, upload-time = "2025-06-05T20:12:39.44Z" },
 ]
 
 [[package]]
@@ -587,9 +628,6 @@ wheels = [
 name = "openslide-python"
 version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pillow" },
-]
 sdist = { url = "https://files.pythonhosted.org/packages/75/f3/11a90efe13994c84ca22bf7d28195e1e6912066dada1960136536c63cdc0/openslide_python-1.4.3.tar.gz", hash = "sha256:06eec2e05988c37b71ff1ee57d1f465c0dcbf26e655d1dcdab70217ad2769b82", size = 386553, upload-time = "2025-12-03T12:12:50.187Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/bb/7a4e12d38616ada03d06fb44658371c2024de92c9d96b9ee95ddb8aa4881/openslide_python-1.4.3-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:e0260a51821266d29fc26f6ca033242b11889a15b814fdf61c286eefd5dac076", size = 33218, upload-time = "2025-12-03T12:12:37.206Z" },
@@ -634,7 +672,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "python-dateutil" },
-    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32' or (extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/da/99/b342345300f13440fe9fe385c3c481e2d9a595ee3bab4d3219247ac94e9a/pandas-3.0.2.tar.gz", hash = "sha256:f4753e73e34c8d83221ba58f232433fca2748be8b18dbca02d242ed153945043", size = 4645855, upload-time = "2026-03-31T06:48:30.816Z" }
 wheels = [
@@ -999,23 +1037,23 @@ dependencies = [
     { name = "fsspec" },
     { name = "jinja2" },
     { name = "networkx" },
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd') or (sys_platform != 'linux' and extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd')" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd') or (sys_platform != 'linux' and extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd')" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd') or (sys_platform != 'linux' and extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd')" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd') or (sys_platform != 'linux' and extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd')" },
+    { name = "nvidia-cudnn-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd') or (sys_platform != 'linux' and extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd')" },
+    { name = "nvidia-cufft-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd') or (sys_platform != 'linux' and extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd')" },
+    { name = "nvidia-cufile-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd') or (sys_platform != 'linux' and extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd')" },
+    { name = "nvidia-curand-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd') or (sys_platform != 'linux' and extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd')" },
+    { name = "nvidia-cusolver-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd') or (sys_platform != 'linux' and extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd')" },
+    { name = "nvidia-cusparse-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd') or (sys_platform != 'linux' and extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd')" },
+    { name = "nvidia-cusparselt-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd') or (sys_platform != 'linux' and extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd')" },
+    { name = "nvidia-nccl-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd') or (sys_platform != 'linux' and extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd') or (sys_platform != 'linux' and extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd')" },
+    { name = "nvidia-nvtx-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd') or (sys_platform != 'linux' and extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd')" },
     { name = "setuptools" },
     { name = "sympy" },
-    { name = "triton", marker = "sys_platform == 'linux'" },
+    { name = "triton", marker = "sys_platform == 'linux' or (extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd')" },
     { name = "typing-extensions" },
 ]
 wheels = [
@@ -1030,7 +1068,6 @@ version = "0.23.0+cu129"
 source = { registry = "https://download.pytorch.org/whl/cu129" }
 dependencies = [
     { name = "numpy" },
-    { name = "pillow" },
     { name = "torch" },
 ]
 wheels = [
@@ -1043,7 +1080,7 @@ name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'group-8-nanopath-pillow' and extra == 'group-8-nanopath-simd')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -273,6 +273,33 @@ wheels = [
 ]
 
 [[package]]
+name = "kornia"
+version = "0.8.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "kornia-rs" },
+    { name = "packaging" },
+    { name = "torch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/80/460e9dad0c1b68f3e83f198f3983638d62f910a88542b492290010d25f50/kornia-0.8.3.tar.gz", hash = "sha256:c06887374eaf39fb614a77ca054383e6cc2092cb7225e45437111b4984d0f866", size = 727384, upload-time = "2026-05-19T20:23:35.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/05/0c1cc486e87d2a5ad6649eb96a8ccaa7c6002d8d73d676c13e2102f286c1/kornia-0.8.3-py3-none-any.whl", hash = "sha256:0b15f5d359aeafd7ff54ea631ed1943a3eb295c4a6dae3f745ddeada25e33289", size = 1189381, upload-time = "2026-05-19T20:23:33.209Z" },
+]
+
+[[package]]
+name = "kornia-rs"
+version = "0.1.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/0f/cd6985790031ad2f0d4fcdfdb9763a177bebb970edddc6fe29f9e6afd902/kornia_rs-0.1.14.tar.gz", hash = "sha256:7584f654a9db2b41bee05c9aaf865608b665e2f7195096372e001b6f220de1d2", size = 2556658, upload-time = "2026-05-19T07:45:06.366Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/e3/e57480f38e395262616afd8efe91d0a1f7a4b875b52c9890e31aa85a057c/kornia_rs-0.1.14-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:76faf5389b1ea53452fc08561622ccad8ce81c8ff1857c4742be6ae4e82bf078", size = 3555313, upload-time = "2026-05-19T07:46:01.714Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/4f/2935c5186cce45bfa85b587883d627627427bceb61d0b0e0aa0267339910/kornia_rs-0.1.14-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0025db9854f3a34c66123c2646d52e71a534678d9343f3c897192136b2c3ddaf", size = 3349262, upload-time = "2026-05-19T07:45:47.689Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/f5/dc5e8f69130de7ed8d59500789bc0cf1658ada8d5360164e416622cb47f1/kornia_rs-0.1.14-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:747b26a3ce0cad76aa1047ed65f95dcd649286a2d5417d8ad93f03bb1909238d", size = 3381293, upload-time = "2026-05-19T07:45:10.552Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7f/01c9456a09a3a5731bf986724f6f6ff70d627ac8072cf298d842ec204692/kornia_rs-0.1.14-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:396f84661fcf260885c3f9db717caf6904eafd44857dca17be09a835bd7da8d9", size = 3695565, upload-time = "2026-05-19T07:45:30.01Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/6f/01e0e2cf90c47ecf26656263cdabe491a1b206c94c0c30a1dd7e4d13ed29/kornia_rs-0.1.14-cp312-cp312-win_amd64.whl", hash = "sha256:ac4bbd0a8fd73b5058a39707c790fecec4c5204a42d1f5af17f1fa57cc83d406", size = 3367565, upload-time = "2026-05-19T07:46:16.682Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -342,10 +369,16 @@ dependencies = [
     { name = "wandb" },
 ]
 
+[package.optional-dependencies]
+gpu = [
+    { name = "kornia" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "h5py", specifier = ">=3.16.0" },
     { name = "huggingface-hub", specifier = ">=0.30.0" },
+    { name = "kornia", marker = "extra == 'gpu'", specifier = "==0.8.3" },
     { name = "numpy", specifier = ">=2.2.0" },
     { name = "openslide-bin", specifier = ">=4.0.0" },
     { name = "openslide-python", specifier = ">=1.4.0" },
@@ -359,6 +392,7 @@ requires-dist = [
     { name = "torchvision", specifier = "==0.23.0+cu129", index = "https://download.pytorch.org/whl/cu129" },
     { name = "wandb", specifier = ">=0.20.0" },
 ]
+provides-extras = ["gpu"]
 
 [[package]]
 name = "networkx"


### PR DESCRIPTION
This PR adds optional model/loss compilation using torch.compile, fused AdamW, GPU augmentation, and Pillow-SIMD. All performance flags currently default to on.

Training is now 2.3× faster for main and 3.8× faster for robust-huelocal. Including setup, calibration, and successful probes, total time fell from ~88 to ~50 minutes and ~168 to ~66 minutes, respectively. These modifications change numerics, but the differences are within expectations.

Recipe | Training | Probes | Total | Score
-- | -- | -- | -- | --
main | ~66 min | ~21 min | ~88 min | 0.6268
Main, all performance options | ~28 min | ~20 min | ~50 min | 0.6265
robust-huelocal | ~145 min | ~20 min | ~168 min | 0.6681
robust-huelocal, all performance options | ~39 min | ~22 min | ~66 min | 0.6716

Each option can be turned on or off by itself using the train config:
```yaml
train:
  compile: true
  fused_adamw: true
  gpu_augment: true
  num_workers: 8
```

| Augmentation | Compile + fused AdamW | Tiles/second |
|---|---|---:|
| Original CPU | Off | ~300 |
| Pillow-SIMD | On | ~350 |
| Pillow + GPU augmentations | Off | ~420 |
| Pillow + GPU augmentations | On | ~660 |
| Pillow-SIMD + GPU augmentations | On | ~690 |